### PR TITLE
Replace IKVM BigInteger usage

### DIFF
--- a/FlashEditor/Cache/CheckSum/ChecksumTable.cs
+++ b/FlashEditor/Cache/CheckSum/ChecksumTable.cs
@@ -1,7 +1,7 @@
-﻿using FlashEditor.Cache.CheckSum;
+using FlashEditor.Cache.CheckSum;
 using FlashEditor.Cache.Util;
 using FlashEditor.Cache.Util.Crypto;
-using java.math;
+using System.Numerics;
 using System;
 
 namespace FlashEditor.Cache {

--- a/FlashEditor/Cache/Util/Crypto/RSA.cs
+++ b/FlashEditor/Cache/Util/Crypto/RSA.cs
@@ -1,4 +1,4 @@
-﻿using java.math;
+using System.Numerics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,10 +24,24 @@ namespace FlashEditor.Cache.Util.Crypto {
             byte[] bytes = new byte[buffer.Length];
             buffer.Read(bytes, 0, bytes.Length);
 
-            BigInteger xin = new BigInteger(bytes);
-            BigInteger xout = xin.modPow(key, modulus);
+            // .NET's BigInteger expects little-endian input. Convert from the
+            // big-endian format used by the cache.
+            Array.Reverse(bytes);
+            byte[] temp = new byte[bytes.Length + 1];
+            Array.Copy(bytes, 0, temp, 0, bytes.Length);
 
-            return new JagStream(xout.toByteArray());
+            BigInteger xin = new BigInteger(temp);
+            BigInteger xout = BigInteger.ModPow(xin, key, modulus);
+
+            // Convert back to big-endian for the output buffer.
+            byte[] outBytes = xout.ToByteArray();
+            int trim = outBytes.Length;
+            while(trim > 1 && outBytes[trim - 1] == 0)
+                trim--;
+            Array.Resize(ref outBytes, trim);
+            Array.Reverse(outBytes);
+
+            return new JagStream(outBytes);
         }
     }
 }

--- a/Tests.Unit/CryptoTests.cs
+++ b/Tests.Unit/CryptoTests.cs
@@ -1,0 +1,43 @@
+using Xunit;
+using FlashEditor.Cache.Util.Crypto;
+using System.Numerics;
+using FlashEditor;
+
+public class CryptoTests
+{
+    [Fact]
+    public void Djb2ProducesExpectedHash()
+    {
+        int hash = Djb2.Hash("test");
+        Assert.Equal(3556498, hash);
+    }
+
+    [Fact]
+    public void XteaRoundTrip()
+    {
+        var stream = new JagStream();
+        stream.WriteInteger(0x12345678);
+        int[] key = {1,2,3,4};
+        XTEA.Encipher(stream, 0, (int)stream.Length, key);
+        XTEA.Decipher(stream, 0, (int)stream.Length, key);
+        stream.Seek0();
+        Assert.Equal(0x12345678, stream.ReadInt());
+    }
+
+    [Fact]
+    public void CRC32MatchesZlib()
+    {
+        byte[] data = System.Text.Encoding.ASCII.GetBytes("hello world");
+        int crc = FlashEditor.Cache.Util.CRC32Generator.GetHash(data);
+        Assert.Equal(222957957, crc);
+    }
+
+    [Fact]
+    public void JagStreamReadWriteInt()
+    {
+        var s = new JagStream();
+        s.WriteInteger(unchecked((int)0xCAFEBABE));
+        s.Seek0();
+        Assert.Equal(unchecked((int)0xCAFEBABE), s.ReadInt());
+    }
+}

--- a/Tests.Unit/DebugUtilStub.cs
+++ b/Tests.Unit/DebugUtilStub.cs
@@ -1,0 +1,5 @@
+namespace FlashEditor.utils {
+    public static class DebugUtil {
+        public static void Debug(string output) { }
+    }
+}

--- a/Tests.Unit/JagStream.cs
+++ b/Tests.Unit/JagStream.cs
@@ -1,0 +1,370 @@
+using FlashEditor.utils;
+using System;
+using System.IO;
+using System.Text;
+
+namespace FlashEditor {
+    public class JagStream : MemoryStream {
+        public JagStream(int size) : base(size) { }
+        public JagStream(byte[] buffer) : base(buffer) { }
+        public JagStream() { }
+
+        /*
+         * The modified set of 'extended ASCII' characters used by the client.
+         */
+        private static char[] CHARACTERS = { '\u20AC', '\0', '\u201A', '\u0192', '\u201E', '\u2026', '\u2020', '\u2021',
+            '\u02C6', '\u2030', '\u0160', '\u2039', '\u0152', '\0', '\u017D', '\0', '\0', '\u2018', '\u2019', '\u201C',
+            '\u201D', '\u2022', '\u2013', '\u2014', '\u02DC', '\u2122', '\u0161', '\u203A', '\u0153', '\0', '\u017E',
+            '\u0178' };
+
+        /*
+         * Loading stream from file
+         */
+        public static JagStream LoadStream(string directory) {
+            if(!File.Exists(directory))
+                throw new FileNotFoundException("'" + directory + "' could not be found.");
+
+            byte[] data = File.ReadAllBytes(directory);
+
+            //We initialise it like this to ensure the stream is expandable
+            JagStream stream = new JagStream();
+            stream.Write(data, 0, data.Length);
+            return stream;
+        }
+
+        /// <summary>
+        /// The limit is set to the current position and then the position is set to zero.
+        /// If the mark is defined then it is discarded.
+        /// </summary>
+        /// <returns>The buffer</returns>
+        internal JagStream Flip() {
+            if(Position == 0 && Length > 0)
+                throw new IOException("Idiot you're destroying the stream");
+            SetLength(Position);
+            Seek0();
+            return this;
+        }
+
+        ///<summary>
+        ///Writes binary data from a JagStream to a file
+        /// </summary>
+        /// <param name="stream">The stream to write to file</param>
+        /// <param name="directory">The directory to write the file to</param>
+        public static void Save(JagStream stream, string directory) {
+            if(stream == null)
+                throw new NullReferenceException("Stream was null");
+
+            using(FileStream file = new FileStream(directory, FileMode.Create, FileAccess.Write))
+                file.Write(stream.ToArray(), 0, (int) stream.Length);
+        }
+
+        public void Save(string directory) {
+            Save(this, directory);
+        }
+
+        /*
+         * Stream reading utils
+         */
+
+        public long Seek0() {
+            return Seek(0);
+        }
+
+        public long Seek(long offset) {
+            return Seek(offset, SeekOrigin.Begin);
+        }
+
+        /*
+         * Methods for reading data from the stream
+         */
+
+        public int ReadVarInt() {
+            byte val = (byte) ReadByte();
+
+            int k;
+            for(k = 0; val < 0; val = (byte) ReadByte())
+                k = (k | val & 0x7F) << 7;
+
+            return k | val;
+        }
+
+        /// <summary>
+        /// Read's smart_v1 from buffer.
+        /// </summary>
+        /// <returns></returns>
+        public int ReadSmart() {
+            int first = ReadUnsignedByte();
+            Position -= 1; // go back a one.
+            if(first < 128)
+                return ReadUnsignedByte();
+            return ReadUnsignedShort() - 32768;
+        }
+
+        public int ReadUnsignedSmart() {
+            int first = ReadUnsignedByte();
+            Position -= 1; // go back a one.
+            return first < 128 ? ReadUnsignedByte() - 64
+                    : ReadUnsignedShort() - 49152;
+        }
+
+        public int ReadSpecialSmart() {
+            int first = ReadUnsignedByte();
+            Position -= 1; // go back a one.
+            if(first < 128)
+                return ReadUnsignedByte() - 1;
+            return ReadUnsignedShort() - 32769;
+        }
+
+        internal int ReadInt() {
+            return (ReadUnsignedByte() << 24) + (ReadUnsignedByte() << 16) + (ReadUnsignedByte() << 8) + ReadUnsignedByte();
+        }
+
+        internal int ReadMedium() {
+            return (ReadUnsignedByte() << 16) + (ReadUnsignedByte() << 8) + ReadUnsignedByte();
+        }
+
+        internal byte ReadUnsignedByte() {
+            int result = ReadByte();
+            if(result == -1)
+                throw new EndOfStreamException("End of stream bro");
+
+            return (byte) result;
+        }
+
+        internal int[] ReadUnsignedByteArray(int size) {
+            byte[] byteBuffer = new byte[size];
+            Read(byteBuffer, 0, byteBuffer.Length);
+            return Array.ConvertAll(byteBuffer, Convert.ToInt32);
+        }
+
+        internal int ReadUnsignedShort() {
+            return (ReadByte() << 8) | ReadByte();
+        }
+        internal int[] ReadUnsignedShortArray(int size) {
+            //Read 2x length contiguous block of bytes
+            byte[] byteBuffer = new byte[size * 2];
+            Read(byteBuffer, 0, byteBuffer.Length);
+
+            int[] shortBuffer = new int[size];
+
+            int k = 0;
+
+            //Recombine into shorts
+            for(int i = 0; i < size; i++) {
+                shortBuffer[i] = (byteBuffer[k] << 8) | byteBuffer[k + 1];
+                k += 2;
+            }
+
+            return shortBuffer;
+        }
+
+        internal string ReadString2() {
+            StringBuilder sb = new StringBuilder();
+            int b;
+
+            while((b = ReadByte()) != 0)
+                sb.Append((char) b);
+
+            return sb.ToString();
+        }
+
+        /**
+         * Gets a null-terminated string from the specified buffer, using a
+         * modified ISO-8859-1 character set.
+         * @param buf The buffer.
+         * @return The decoded string.
+         */
+        public string ReadJagexString() {
+            StringBuilder sb = new StringBuilder();
+            int b;
+            while((b = ReadByte()) != 0) {
+                //If the byte read is between 127 and 159, it should be remapped
+                if(b >= 127 && b < 160) {
+                    char c = CHARACTERS[b - 128];
+                    if(c.Equals('\0')) //if it needs to be remapped, as per the characters array
+                        c = '\u003F'; //replace with question mark as placeholder to avoid rendering issues
+                    sb.Append(c);
+                } else {
+                    sb.Append((char) b);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        internal byte Get(int pos) {
+            //Store the current position
+            long tempPosition = Position;
+
+            //Move the the desired position
+            Seek(pos);
+
+            byte x = (byte) ReadByte();
+
+            //Reset the position
+            Position = tempPosition;
+
+            return x;
+        }
+
+        internal void Skip(int skip) {
+            Position += skip;
+        }
+
+        //Seems to work better? idk tbh my brain is fried...
+        public string ReadFlashString() {
+            StringBuilder sb = new StringBuilder();
+            int b;
+            while((b = ReadByte()) != 0) {
+                if(b >= 128 && b < 160) {
+                    char c = CHARACTERS[b - 128];
+                    sb.Append(c == (char) 0 ? (char) 63 : c);
+                } else {
+                    //Nobody seems to have this (including client, openrs, etc)
+                    //Seems to eliminate issues reading strings not terminated by 0
+                    if(b < 32) {
+                        //But also should we reduce the position because we over-read the stream?
+                        Position--;
+                        break;
+                    }
+
+                    sb.Append((char) b);
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /*
+         * Methods for writing to the JagStream
+         */
+
+        internal void WriteString(string s) {
+            foreach(char c in s.ToCharArray())
+                WriteByte((byte) c);
+
+            //terminate the string with 0
+            WriteByte(0);
+
+            //apparently 317 format is terminated with 10
+        }
+
+        /**
+         * Interesting method ripped from kfricilone's openRS
+         * Converts the contents of the specified byte buffer to a string, which is
+        * formatted similarly to the output of the {@link Arrays#toString()}
+        * method.
+        * 
+        * @param buffer
+        *            The buffer.
+        * @return The string.
+        */
+        /*
+        public static String toString(ByteBuffer buffer) {
+            StringBuilder builder = new StringBuilder("[");
+            for(int i = 0; i < buffer.limit(); i++) {
+                String hex = Integer.toHexString(buffer.get(i) & 0xFF).toUpperCase();
+                if(hex.length() == 1)
+                    hex = "0" + hex;
+
+                builder.append("0x").append(hex);
+                if(i != buffer.limit() - 1) {
+                    builder.append(", ");
+                }
+            }
+            builder.append("]");
+            return builder.toString();
+        }
+        */
+
+        internal void WriteBytes(int bytes, object value) {
+            byte[] data = new byte[bytes];
+
+            if(value is int)
+                data = BitConverter.GetBytes((int) value);
+            if(value is short)
+                data = BitConverter.GetBytes((short) value);
+
+            //Backwards to maintain the correct endianness!
+            for(int k = bytes - 1; k >= 0; k--)
+                WriteByte(data[k]);
+        }
+
+        internal void WriteShort(short value) {
+            WriteBytes(2, value);
+        }
+
+        internal void WriteShort(int value) {
+            WriteShort((short) value);
+        }
+
+        internal void WriteMedium(int value) {
+            WriteBytes(3, value);
+        }
+
+        internal void WriteMedium(long value) {
+            WriteBytes(3, (int) value);
+        }
+
+        internal void WriteVarInt(int var63) {
+            throw new NotImplementedException();
+        }
+
+        internal void WriteInteger(int value) {
+            WriteBytes(4, value);
+        }
+
+        internal void WriteInteger(long value) {
+            WriteInteger((int) value);
+        }
+
+        internal int ReadShort() {
+            int i = ReadUnsignedShort();
+            return i > 32767 ? i -= 0x10000 : i;
+        }
+
+        //Returns a substream starting at ptr with length bytes
+
+        internal JagStream GetSubStream(int length, long ptr) {
+            Seek(ptr);
+            return GetSubStream(length);
+        }
+
+        internal JagStream GetSubStream(int length) {
+            return new JagStream(ReadBytes(length));
+        }
+
+        internal byte[] ReadBytes(long length) {
+            return ReadBytes((int) length);
+        }
+
+        internal byte[] ReadBytes(int length) {
+            byte[] buf = new byte[length];
+            for(int k = 0; k < length; k++)
+                buf[k] = (byte) ReadByte();
+
+            return buf;
+        }
+
+        internal void PutLengthFromMark(long v) {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Clears this buffer. The position is set to zero, the limit is set to the
+        /// capacity, and the mark is discarded.
+        /// </summary>
+        public void Clear() {
+            Seek0();
+            SetLength(Capacity);
+        }
+
+        /// <summary>
+        /// Computes the number of bytes that can be read before reaching the Length (limit)
+        /// </summary>
+        /// <returns>The number of bytes remaining left to be read</returns>
+        public int Remaining() {
+            return (int) (Length - Position);
+        }
+    }
+}

--- a/Tests.Unit/Tests.Unit.csproj
+++ b/Tests.Unit/Tests.Unit.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlashEditor/Cache/Util/Crypto/Djb2.cs" Link="Djb2.cs" />
+    <Compile Include="../FlashEditor/Cache/Util/Crypto/XTEA.cs" Link="XTEA.cs" />
+    <Compile Include="../FlashEditor/Cache/Util/Crypto/RSA.cs" Link="RSA.cs" />
+    <Compile Include="../FlashEditor/Cache/Util/CRC32Generator.cs" Link="CRC32Generator.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- use `System.Numerics.BigInteger` instead of `java.math.BigInteger`
- convert RSA input/output between big-endian and little-endian
- add xUnit project with crypto and JagStream unit tests

## Testing
- `dotnet test Tests.Unit/Tests.Unit.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684ce1e73aa8832d9bf28fd33d6bbf44