### PR TITLE
Switch BigInteger implementation to System.Numerics

### DIFF
--- a/FlashEditor/Cache/CheckSum/ChecksumTable.cs
+++ b/FlashEditor/Cache/CheckSum/ChecksumTable.cs
@@ -1,7 +1,7 @@
 ﻿using FlashEditor.Cache.CheckSum;
 using FlashEditor.Cache.Util;
 using FlashEditor.Cache.Util.Crypto;
-using java.math;
+using System.Numerics;
 using System;
 
 namespace FlashEditor.Cache {
@@ -73,7 +73,7 @@ namespace FlashEditor.Cache {
          * @throws IOException
          *             if an I/O error occurs.
          */
-        public static ChecksumTable Decode(JagStream buffer, bool whirlpool, BigInteger modulus, BigInteger publicKey) {
+        public static ChecksumTable Decode(JagStream buffer, bool whirlpool, BigInteger? modulus, BigInteger? publicKey) {
             //Find out how many entries there are and allocate a new table
             int size = whirlpool ? buffer.ReadUnsignedByte() : ((int) buffer.Length / 8);
             ChecksumTable table = new ChecksumTable(size);
@@ -110,8 +110,8 @@ namespace FlashEditor.Cache {
                 buffer.Read(bytes, 0, bytes.Length);
                 JagStream temp = new JagStream(bytes);
 
-                if(modulus != null && publicKey != null) {
-                    temp = RSA.Crypt(buffer, modulus, publicKey);
+                if(modulus.HasValue && publicKey.HasValue) {
+                    temp = RSA.Crypt(buffer, modulus.Value, publicKey.Value);
                 }
 
                 if(temp.Length != 65)
@@ -141,7 +141,7 @@ namespace FlashEditor.Cache {
             return Encode(whirlpool, null, null);
         }
 
-        public JagStream Encode(bool whirlpool, BigInteger modulus, BigInteger privateKey) {
+        public JagStream Encode(bool whirlpool, BigInteger? modulus, BigInteger? privateKey) {
             /*
             JagStream os = new JagStream();
 
@@ -172,8 +172,8 @@ namespace FlashEditor.Cache {
                     temp.put(Whirlpool.whirlpool(bytes, 0, bytes.Length));
                     temp.Flip();
 
-                    if(modulus != null && privateKey != null) {
-                        temp = RSA.Crypt(temp, modulus, privateKey);
+                    if(modulus.HasValue && privateKey.HasValue) {
+                        temp = RSA.Crypt(temp, modulus.Value, privateKey.Value);
                     }
 
                     bytes = new byte[temp.Length];

--- a/FlashEditor/Cache/Util/Crypto/RSA.cs
+++ b/FlashEditor/Cache/Util/Crypto/RSA.cs
@@ -1,4 +1,4 @@
-﻿using java.math;
+﻿using System.Numerics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,10 +24,23 @@ namespace FlashEditor.Cache.Util.Crypto {
             byte[] bytes = new byte[buffer.Length];
             buffer.Read(bytes, 0, bytes.Length);
 
-            BigInteger xin = new BigInteger(bytes);
-            BigInteger xout = xin.modPow(key, modulus);
+            // System.Numerics.BigInteger expects little-endian byte arrays.
+            Array.Reverse(bytes);
+            byte[] temp = new byte[bytes.Length + 1];
+            Array.Copy(bytes, 0, temp, 0, bytes.Length);
 
-            return new JagStream(xout.toByteArray());
+            BigInteger xin = new BigInteger(temp);
+            BigInteger xout = BigInteger.ModPow(xin, key, modulus);
+
+            // Convert the result back to big-endian.
+            byte[] outBytes = xout.ToByteArray();
+            int trim = outBytes.Length;
+            while(trim > 1 && outBytes[trim - 1] == 0)
+                trim--;
+            Array.Resize(ref outBytes, trim);
+            Array.Reverse(outBytes);
+
+            return new JagStream(outBytes);
         }
     }
 }


### PR DESCRIPTION
## Summary
- swap IKVM `BigInteger` for `System.Numerics.BigInteger`
- use little-endian conversion when performing RSA operations
- allow `ChecksumTable` methods to accept nullable `BigInteger` parameters

## Testing
- `dotnet test FlashEditor.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf0f47864832da85e8d44e03afffe