### PR TITLE
Add xUnit tests and setup guide

### DIFF
--- a/FlashEditor.Tests/Cache/Util/CRC32GeneratorTests.cs
+++ b/FlashEditor.Tests/Cache/Util/CRC32GeneratorTests.cs
@@ -1,0 +1,21 @@
+using FlashEditor.Cache.Util;
+using Xunit;
+
+namespace FlashEditor.Tests.Cache.Util
+{
+    public class CRC32GeneratorTests
+    {
+        [Fact]
+        public void GetHash_KnownValue_ReturnsExpectedCrc()
+        {
+            // Arrange
+            byte[] data = System.Text.Encoding.ASCII.GetBytes("123456789");
+
+            // Act
+            int crc = CRC32Generator.GetHash(data);
+
+            // Assert
+            Assert.Equal(-873187034, crc); // CRC32 for "123456789" is 0xCBF43926
+        }
+    }
+}

--- a/FlashEditor.Tests/Cache/Util/DirectBitmapTests.cs
+++ b/FlashEditor.Tests/Cache/Util/DirectBitmapTests.cs
@@ -1,0 +1,24 @@
+using FlashEditor.Cache.Util;
+using System.Drawing;
+using Xunit;
+
+namespace FlashEditor.Tests.Cache.Util
+{
+    public class DirectBitmapTests
+    {
+        [Fact]
+        public void SetPixel_Then_GetPixel_ReturnsSameColor()
+        {
+            // Arrange
+            using var bmp = new DirectBitmap(2, 2);
+            Color expected = Color.Red;
+
+            // Act
+            bmp.SetPixel(1, 1, expected);
+            var result = bmp.GetPixel(1, 1);
+
+            // Assert
+            Assert.Equal(expected.ToArgb(), result.ToArgb());
+        }
+    }
+}

--- a/FlashEditor.Tests/FlashEditor.Tests.csproj
+++ b/FlashEditor.Tests/FlashEditor.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FlashEditor\FlashEditor.csproj" />
+  </ItemGroup>
+</Project>

--- a/FlashEditor.Tests/IO/JagStreamTests.cs
+++ b/FlashEditor.Tests/IO/JagStreamTests.cs
@@ -1,0 +1,70 @@
+using FlashEditor;
+using Xunit;
+
+namespace FlashEditor.Tests.IO
+{
+    public class JagStreamTests
+    {
+        [Fact]
+        public void WriteAndReadShort_RoundTripsValue()
+        {
+            // Arrange
+            var stream = new JagStream();
+            const short value = 0x1234;
+
+            // Act
+            stream.WriteShort(value);
+            stream.Seek0();
+            int result = stream.ReadUnsignedShort();
+
+            // Assert
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public void WriteAndReadInteger_RoundTripsValue()
+        {
+            // Arrange
+            var stream = new JagStream();
+            const int value = 0x12345678;
+
+            // Act
+            stream.WriteInteger(value);
+            stream.Seek0();
+            int result = stream.ReadInt();
+
+            // Assert
+            Assert.Equal(value, result);
+        }
+
+        [Fact]
+        public void LoadStream_NonExistingFile_ThrowsFileNotFound()
+        {
+            Assert.Throws<System.IO.FileNotFoundException>(() => JagStream.LoadStream("nonexistent.bin"));
+        }
+
+        [Fact]
+        public void Save_And_LoadStream_WritesAndReadsFile()
+        {
+            // Arrange
+            var tempPath = System.IO.Path.GetTempFileName();
+            try
+            {
+                var stream = new JagStream();
+                stream.WriteByte(1);
+
+                // Act
+                JagStream.Save(stream, tempPath);
+                var loaded = JagStream.LoadStream(tempPath);
+
+                // Assert
+                Assert.Equal(new byte[]{1}, loaded.ToArray());
+            }
+            finally
+            {
+                if(System.IO.File.Exists(tempPath))
+                    System.IO.File.Delete(tempPath);
+            }
+        }
+    }
+}

--- a/FlashEditor.Tests/Utils/CompressionUtilsTests.cs
+++ b/FlashEditor.Tests/Utils/CompressionUtilsTests.cs
@@ -1,0 +1,21 @@
+using FlashEditor;
+using Xunit;
+
+namespace FlashEditor.Tests.Utils
+{
+    public class CompressionUtilsTests
+    {
+        [Fact]
+        public void SubArray_ReturnsCorrectSegment()
+        {
+            // Arrange
+            int[] data = {1,2,3,4,5};
+
+            // Act
+            int[] result = CompressionUtils.SubArray(data, 1, 3);
+
+            // Assert
+            Assert.Equal(new[] {2,3,4}, result);
+        }
+    }
+}

--- a/FlashEditor.Tests/Utils/DebugUtilTests.cs
+++ b/FlashEditor.Tests/Utils/DebugUtilTests.cs
@@ -1,0 +1,44 @@
+using FlashEditor.utils;
+using Xunit;
+
+namespace FlashEditor.Tests.Utils
+{
+    public class DebugUtilTests
+    {
+        [Theory]
+        [InlineData((byte)0x3F, "00111111")]
+        [InlineData((byte)0xFF, "11111111")]
+        public void ToBitString_Byte_ReturnsBinaryString(byte input, string expected)
+        {
+            // Act
+            string result = DebugUtil.ToBitString(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData((short)0x1F, "0000000000011111")]
+        [InlineData((short)0xFFFF, "1111111111111111")]
+        public void ToBitString_Short_ReturnsBinaryString(short input, string expected)
+        {
+            // Act
+            string result = DebugUtil.ToBitString(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(1, "00000000000000000000000000000001")]
+        [InlineData(-1, "11111111111111111111111111111111")]
+        public void ToBitString_Int_ReturnsBinaryString(int input, string expected)
+        {
+            // Act
+            string result = DebugUtil.ToBitString(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/FlashEditor.sln
+++ b/FlashEditor.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlashEditor", "FlashEditor\FlashEditor.csproj", "{355AFED6-FE4B-4536-9587-6924BF867A4E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlashEditor.Tests", "FlashEditor.Tests\FlashEditor.Tests.csproj", "{819FD34B-3EDD-414B-B559-CEF76799FFA3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,10 +14,14 @@ Global
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{355AFED6-FE4B-4536-9587-6924BF867A4E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{355AFED6-FE4B-4536-9587-6924BF867A4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{355AFED6-FE4B-4536-9587-6924BF867A4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{355AFED6-FE4B-4536-9587-6924BF867A4E}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {355AFED6-FE4B-4536-9587-6924BF867A4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {355AFED6-FE4B-4536-9587-6924BF867A4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {355AFED6-FE4B-4536-9587-6924BF867A4E}.Release|Any CPU.Build.0 = Release|Any CPU
+                {819FD34B-3EDD-414B-B559-CEF76799FFA3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {819FD34B-3EDD-414B-B559-CEF76799FFA3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {819FD34B-3EDD-414B-B559-CEF76799FFA3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {819FD34B-3EDD-414B-B559-CEF76799FFA3}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/SETUP_TESTS.md
+++ b/SETUP_TESTS.md
@@ -1,0 +1,35 @@
+# Test Project Setup Guide
+
+Follow these steps to create and configure the test projects for this solution.
+
+1. **Create the test project**
+   - In Visual Studio select `Add -> New Project -> xUnit Test Project (.NET Framework)`.
+   - Name the project `FlashEditor.Tests` and target **.NET Framework 4.7.2**.
+
+2. **Add project reference**
+   - Right click the new test project, choose **Add Reference**, and select the `FlashEditor` project.
+
+3. **Install NuGet packages**
+   - Open the Package Manager Console and run:
+     ```
+     Install-Package xunit
+     Install-Package xunit.runner.visualstudio
+     Install-Package Moq
+     ```
+
+4. **Organise folders and namespaces**
+   - Mirror the source structure inside the test project under folders such as `Utils/`, `IO/`, and `Cache/Util/`.
+   - Use namespaces that mirror the production namespaces with `.Tests` suffix, e.g. `FlashEditor.Tests.Utils`.
+
+5. **Running the tests**
+   - Build the solution and open the **Test Explorer** window.
+   - All tests should appear automatically thanks to the xUnit Visual Studio runner.
+   - Use `dotnet test` or `vstest.console.exe` if executing from command line.
+
+6. **CI Integration**
+   - In your pipeline add a task similar to:
+     ```yaml
+     - script: dotnet test --configuration Release --no-build
+       displayName: 'Run xUnit tests'
+     ```
+   - The build should fail automatically if any tests fail.


### PR DESCRIPTION
## Summary
- add an xUnit test project targeting .NET Framework 4.7.2
- add tests covering utility classes (compression, debug helpers, CRC32, stream helpers, and bitmap wrapper)
- update solution to include the test project
- document how to set up and run the tests

## Testing
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e2b970414832d873eadc5459e55ce