### PR TITLE
Fix test accessibility

### DIFF
--- a/FlashEditor.Tests/FlashEditor.Tests.csproj
+++ b/FlashEditor.Tests/FlashEditor.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Enable modern C# language features for tests -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/FlashEditor/Properties/AssemblyInfo.cs
+++ b/FlashEditor/Properties/AssemblyInfo.cs
@@ -34,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Allow the test project to access internal members
+[assembly: InternalsVisibleTo("FlashEditor.Tests")]


### PR DESCRIPTION
## Summary
- enable modern C# features in FlashEditor.Tests
- expose internal members to the test project

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e32cd21b4832d8c5c6a0355df85d8