### PR TITLE
Make JagStream and debug utils public

### DIFF
--- a/FlashEditor.Tests/FlashEditor.Tests.csproj
+++ b/FlashEditor.Tests/FlashEditor.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Enable modern C# language features for tests -->
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.5.0" />

--- a/FlashEditor/IO/JagStream.cs
+++ b/FlashEditor/IO/JagStream.cs
@@ -118,7 +118,7 @@ namespace FlashEditor {
             return ReadUnsignedShort() - 32769;
         }
 
-        internal int ReadInt() {
+        public int ReadInt() {
             return (ReadUnsignedByte() << 24) + (ReadUnsignedByte() << 16) + (ReadUnsignedByte() << 8) + ReadUnsignedByte();
         }
 
@@ -314,11 +314,11 @@ namespace FlashEditor {
             throw new NotImplementedException();
         }
 
-        internal void WriteInteger(int value) {
+        public void WriteInteger(int value) {
             WriteBytes(4, value);
         }
 
-        internal void WriteInteger(long value) {
+        public void WriteInteger(long value) {
             WriteInteger((int) value);
         }
 

--- a/FlashEditor/Properties/AssemblyInfo.cs
+++ b/FlashEditor/Properties/AssemblyInfo.cs
@@ -34,3 +34,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Allow the test project to access internal members
+[assembly: InternalsVisibleTo("FlashEditor.Tests")]

--- a/FlashEditor/Utils/Debugging.cs
+++ b/FlashEditor/Utils/Debugging.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Newtonsoft.Json.Linq;
 
 namespace FlashEditor.utils {
-    class DebugUtil {
+    public static class DebugUtil {
         //Change the order of the indexes when you change the layout of the editor tabs
         public enum LOG_DETAIL {
             NONE = 0,


### PR DESCRIPTION
## Summary
- open access to `JagStream` integer helpers
- expose `DebugUtil` to other projects

## Testing
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj -c Debug` *(fails: .NET Framework 4.7.2 targeting pack missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e32cd21b4832d8c5c6a0355df85d8