### PR TITLE
Add tests and setup guidance

### DIFF
--- a/FlashEditor.Tests/Cache/Util/CRC32GeneratorTests.cs
+++ b/FlashEditor.Tests/Cache/Util/CRC32GeneratorTests.cs
@@ -17,5 +17,33 @@ namespace FlashEditor.Tests.Cache.Util
             // Assert
             Assert.Equal(-873187034, crc); // CRC32 for "123456789" is 0xCBF43926
         }
+
+        [Fact]
+        public void GetHash_ArraySegment_ReturnsSameAsWholeArray()
+        {
+            // Arrange
+            byte[] data = {1, 2, 3, 4, 5};
+            var segment = new System.ArraySegment<byte>(data, 1, 3);
+
+            // Act
+            int fullHash = CRC32Generator.GetHash(data, 1, 3);
+            int segHash = CRC32Generator.GetHash(segment);
+
+            // Assert
+            Assert.Equal(fullHash, segHash);
+        }
+
+        [Fact]
+        public void UpdateByte_UpdatesInternalValue()
+        {
+            // Arrange
+            var crc = new CRC32Generator();
+
+            // Act
+            crc.UpdateByte(0xFF);
+
+            // Assert
+            Assert.NotEqual(~CRC32Generator.GetHash(new byte[0]), crc.Value);
+        }
     }
 }

--- a/FlashEditor.Tests/Cache/Util/DirectBitmapTests.cs
+++ b/FlashEditor.Tests/Cache/Util/DirectBitmapTests.cs
@@ -20,5 +20,29 @@ namespace FlashEditor.Tests.Cache.Util
             // Assert
             Assert.Equal(expected.ToArgb(), result.ToArgb());
         }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void Save_WritesBitmapToFile()
+        {
+            // Arrange
+            using var bmp = new DirectBitmap(1, 1);
+            bmp.SetPixel(0, 0, Color.Blue);
+            string path = System.IO.Path.GetTempFileName();
+
+            try
+            {
+                // Act
+                bmp.Save(path);
+
+                // Assert
+                Assert.True(System.IO.File.Exists(path));
+            }
+            finally
+            {
+                if (System.IO.File.Exists(path))
+                    System.IO.File.Delete(path);
+            }
+        }
     }
 }

--- a/FlashEditor.Tests/FlashEditor.Tests.csproj
+++ b/FlashEditor.Tests/FlashEditor.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlashEditor\FlashEditor.csproj" />

--- a/FlashEditor.Tests/IO/JagStreamTests.cs
+++ b/FlashEditor.Tests/IO/JagStreamTests.cs
@@ -66,5 +66,35 @@ namespace FlashEditor.Tests.IO
                     System.IO.File.Delete(tempPath);
             }
         }
+
+        [Fact]
+        public void ReadJagexString_WithExtendedCharacters_DecodesCorrectly()
+        {
+            // Arrange
+            byte[] bytes = { (byte)'H', (byte)'i', 0 };
+            var stream = new JagStream(bytes);
+
+            // Act
+            string result = stream.ReadJagexString();
+
+            // Assert
+            Assert.Equal("Hi", result);
+        }
+
+        [Fact]
+        public void ReadUnsignedShortArray_ReadsAllValues()
+        {
+            // Arrange
+            var stream = new JagStream();
+            stream.WriteShort((short)1);
+            stream.WriteShort((short)2);
+            stream.Seek0();
+
+            // Act
+            int[] result = stream.ReadUnsignedShortArray(2);
+
+            // Assert
+            Assert.Equal(new[]{1,2}, result);
+        }
     }
 }

--- a/FlashEditor.Tests/Utils/CompressionUtilsTests.cs
+++ b/FlashEditor.Tests/Utils/CompressionUtilsTests.cs
@@ -17,5 +17,33 @@ namespace FlashEditor.Tests.Utils
             // Assert
             Assert.Equal(new[] {2,3,4}, result);
         }
+
+        [Fact]
+        public void Gzip_Then_Gunzip_RoundTripsBytes()
+        {
+            // Arrange
+            byte[] data = {1, 2, 3, 4};
+
+            // Act
+            byte[] compressed = CompressionUtils.Gzip(data);
+            byte[] result = CompressionUtils.Gunzip(compressed);
+
+            // Assert
+            Assert.Equal(data, result);
+        }
+
+        [Fact]
+        public void Bzip2_Then_Bunzip2_RoundTripsBytes()
+        {
+            // Arrange
+            byte[] data = {5, 6, 7, 8};
+
+            // Act
+            byte[] compressed = CompressionUtils.Bzip2(data);
+            byte[] result = CompressionUtils.Bunzip2(compressed, data.Length);
+
+            // Assert
+            Assert.Equal(data, result);
+        }
     }
 }

--- a/FlashEditor.Tests/Utils/DebugUtilTests.cs
+++ b/FlashEditor.Tests/Utils/DebugUtilTests.cs
@@ -40,5 +40,28 @@ namespace FlashEditor.Tests.Utils
             // Assert
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void PrintByteArray_WritesExpectedFormat()
+        {
+            // Arrange
+            byte[] data = {1, 2, 3};
+            using var writer = new System.IO.StringWriter();
+            var originalOut = System.Console.Out;
+            System.Console.SetOut(writer);
+
+            try
+            {
+                // Act
+                DebugUtil.PrintByteArray(data);
+            }
+            finally
+            {
+                System.Console.SetOut(originalOut);
+            }
+
+            // Assert
+            Assert.Contains("3/3", writer.ToString());
+        }
     }
 }

--- a/FlashEditor/FlashEditor.csproj
+++ b/FlashEditor/FlashEditor.csproj
@@ -53,6 +53,9 @@
   <PropertyGroup>
     <StartupObject>FlashEditor.FlashEditorForm</StartupObject>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+  </ItemGroup>
   <PropertyGroup>
     <ApplicationIcon>
     </ApplicationIcon>
@@ -272,4 +275,5 @@
     <Folder Include="Cache\Type\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.net472/1.0.3/build/Microsoft.NETFramework.ReferenceAssemblies.net472.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.netframework.referenceassemblies.net472/1.0.3/build/Microsoft.NETFramework.ReferenceAssemblies.net472.targets')" />
 </Project>

--- a/SETUP_TESTS.md
+++ b/SETUP_TESTS.md
@@ -13,9 +13,10 @@ Follow these steps to create and configure the test projects for this solution.
    - Open the Package Manager Console and run:
      ```
      Install-Package xunit
-     Install-Package xunit.runner.visualstudio
-     Install-Package Moq
-     ```
+    Install-Package xunit.runner.visualstudio
+    Install-Package Moq
+    Install-Package Microsoft.NETFramework.ReferenceAssemblies.net472
+    ```
 
 4. **Organise folders and namespaces**
    - Mirror the source structure inside the test project under folders such as `Utils/`, `IO/`, and `Cache/Util/`.
@@ -25,6 +26,9 @@ Follow these steps to create and configure the test projects for this solution.
    - Build the solution and open the **Test Explorer** window.
    - All tests should appear automatically thanks to the xUnit Visual Studio runner.
    - Use `dotnet test` or `vstest.console.exe` if executing from command line.
+   - If building on a machine without the .NET Framework developer packs, the
+     `Microsoft.NETFramework.ReferenceAssemblies.net472` package provides the
+     reference assemblies so `dotnet test` can compile the projects.
 
 6. **CI Integration**
    - In your pipeline add a task similar to:


### PR DESCRIPTION
## Summary
- extend CRC32Generator, DirectBitmap, JagStream, CompressionUtils, and DebugUtil tests
- reference .NET Framework assemblies and update build props
- expand test setup instructions

## Testing
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj -v minimal` *(fails: Non-string resources require System.Resources.Extensions; missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_684e4350423c832d805a7f61a1cc59e1