### PR TITLE
Add codec roundtrip tests

### DIFF
--- a/FlashEditor.Tests/Cache/CodecTests.cs
+++ b/FlashEditor.Tests/Cache/CodecTests.cs
@@ -1,0 +1,76 @@
+using FlashEditor;
+using FlashEditor.cache;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FlashEditor.Tests.Cache
+{
+    public class CodecTests
+    {
+        [Fact]
+        public void ReferenceTable_EncodeDecode_RoundTrips()
+        {
+            // Arrange - build a minimal reference table with one entry and one child
+            var table = new RSReferenceTable
+            {
+                format = 6,
+                version = 1,
+                flags = 0
+            };
+
+            var entry = new RSEntry(0);
+            entry.SetVersion(1);
+            entry.SetValidFileIds(new int[] { 0 });
+            entry.SetChildEntries(new SortedDictionary<int, RSChildEntry>
+            {
+                { 0, new RSChildEntry(0) }
+            });
+
+            table.PutEntry(0, entry);
+
+            // Act
+            JagStream encoded = table.Encode();
+            RSReferenceTable decoded = RSReferenceTable.Decode(new JagStream(encoded.ToArray()));
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+
+        [Fact]
+        public void Container_EncodeDecode_RoundTrips()
+        {
+            // Arrange
+            var payload = new JagStream();
+            payload.WriteByte(1);
+            payload.WriteByte(2);
+            var container = new RSContainer(RSConstants.ITEM_DEFINITIONS_INDEX, 0,
+                                            RSConstants.NO_COMPRESSION, payload, 1);
+
+            // Act
+            JagStream encoded = container.Encode();
+            RSContainer decoded = RSContainer.Decode(new JagStream(encoded.ToArray()));
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+
+        [Fact]
+        public void Archive_EncodeDecode_RoundTrips()
+        {
+            // Arrange
+            var archive = new RSArchive();
+            archive.PutEntry(0, new JagStream(new byte[] { 1, 2, 3 }));
+            archive.PutEntry(1, new JagStream(new byte[] { 4, 5 }));
+
+            // Act
+            JagStream encoded = archive.Encode();
+            RSArchive decoded = RSArchive.Decode(new JagStream(encoded.ToArray()), archive.EntryCount());
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+    }
+}

--- a/FlashEditor/FlashEditor.csproj
+++ b/FlashEditor/FlashEditor.csproj
@@ -52,7 +52,11 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>FlashEditor.FlashEditorForm</StartupObject>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Resources.Extensions" Version="7.0.0" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- create codec roundtrip tests for RSReferenceTable, RSContainer, and RSArchive
- allow building resources on new SDK by enabling preserialized resources
- add `System.Resources.Extensions` package so WinForms project compiles

## Testing
- `dotnet restore FlashEditor.sln`
- `dotnet test` *(fails: could not resolve IKVM/OpenTK assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b8d38ac832d888077249114ee7e