### PR TITLE
Ensure JagStream.Save creates directories

### DIFF
--- a/FlashEditor.Tests/IO/JagStreamTests.cs
+++ b/FlashEditor.Tests/IO/JagStreamTests.cs
@@ -68,6 +68,30 @@ namespace FlashEditor.Tests.IO
         }
 
         [Fact]
+        public void Save_CreatesDirectoryIfMissing()
+        {
+            // Arrange
+            string dir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.Guid.NewGuid().ToString());
+            string file = System.IO.Path.Combine(dir, "test.bin");
+            var stream = new JagStream();
+            stream.WriteByte(42);
+
+            try
+            {
+                // Act
+                JagStream.Save(stream, file);
+
+                // Assert
+                Assert.True(System.IO.File.Exists(file));
+            }
+            finally
+            {
+                if(System.IO.Directory.Exists(dir))
+                    System.IO.Directory.Delete(dir, true);
+            }
+        }
+
+        [Fact]
         public void ReadJagexString_WithExtendedCharacters_DecodesCorrectly()
         {
             // Arrange

--- a/FlashEditor/IO/JagStream.cs
+++ b/FlashEditor/IO/JagStream.cs
@@ -57,6 +57,10 @@ namespace FlashEditor {
             if(stream == null)
                 throw new NullReferenceException("Stream was null");
 
+            string dirName = Path.GetDirectoryName(directory);
+            if(!string.IsNullOrEmpty(dirName) && !Directory.Exists(dirName))
+                Directory.CreateDirectory(dirName);
+
             using(FileStream file = new FileStream(directory, FileMode.Create, FileAccess.Write))
                 file.Write(stream.ToArray(), 0, (int) stream.Length);
         }


### PR DESCRIPTION
## Summary
- create directory tree in `JagStream.Save`
- add unit test verifying missing directories are created
- drop nullable reference annotation for C# 7.3 compatibility

## Testing
- `dotnet test --no-build` *(fails: Build failed with missing assemblies)*

------
https://chatgpt.com/codex/tasks/task_e_684e49592c18832da0d8eb7db6f9f722