### PR TITLE
Fix test project setup

### DIFF
--- a/FlashEditor.Tests/Cache/CodecTests.cs
+++ b/FlashEditor.Tests/Cache/CodecTests.cs
@@ -1,0 +1,76 @@
+using FlashEditor;
+using FlashEditor.cache;
+using System.Collections.Generic;
+using Xunit;
+
+namespace FlashEditor.Tests.Cache
+{
+    public class CodecTests
+    {
+        [Fact]
+        public void ReferenceTable_EncodeDecode_RoundTrips()
+        {
+            // Arrange - build a minimal reference table with one entry and one child
+            var table = new RSReferenceTable
+            {
+                format = 6,
+                version = 1,
+                flags = 0
+            };
+
+            var entry = new RSEntry(0);
+            entry.SetVersion(1);
+            entry.SetValidFileIds(new int[] { 0 });
+            entry.SetChildEntries(new SortedDictionary<int, RSChildEntry>
+            {
+                { 0, new RSChildEntry(0) }
+            });
+
+            table.PutEntry(0, entry);
+
+            // Act
+            JagStream encoded = table.Encode();
+            RSReferenceTable decoded = RSReferenceTable.Decode(new JagStream(encoded.ToArray()));
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+
+        [Fact]
+        public void Container_EncodeDecode_RoundTrips()
+        {
+            // Arrange
+            var payload = new JagStream();
+            payload.WriteByte(1);
+            payload.WriteByte(2);
+            var container = new RSContainer(RSConstants.ITEM_DEFINITIONS_INDEX, 0,
+                                            RSConstants.NO_COMPRESSION, payload, 1);
+
+            // Act
+            JagStream encoded = container.Encode();
+            RSContainer decoded = RSContainer.Decode(new JagStream(encoded.ToArray()));
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+
+        [Fact]
+        public void Archive_EncodeDecode_RoundTrips()
+        {
+            // Arrange
+            var archive = new RSArchive();
+            archive.PutEntry(0, new JagStream(new byte[] { 1, 2, 3 }));
+            archive.PutEntry(1, new JagStream(new byte[] { 4, 5 }));
+
+            // Act
+            JagStream encoded = archive.Encode();
+            RSArchive decoded = RSArchive.Decode(new JagStream(encoded.ToArray()), archive.EntryCount());
+            JagStream reencoded = decoded.Encode();
+
+            // Assert
+            Assert.Equal(encoded.ToArray(), reencoded.ToArray());
+        }
+    }
+}

--- a/FlashEditor.Tests/FlashEditor.Tests.csproj
+++ b/FlashEditor.Tests/FlashEditor.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
     <!-- Use modern C# features while targeting .NET Framework -->
     <LangVersion>11.0</LangVersion>
     <ImplicitUsings>false</ImplicitUsings>
@@ -11,6 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlashEditor\FlashEditor.csproj" />

--- a/FlashEditor/FlashEditor.csproj
+++ b/FlashEditor/FlashEditor.csproj
@@ -12,6 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <LangVersion>11.0</LangVersion>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile />
     <PublishUrl>publish\</PublishUrl>
@@ -52,9 +53,13 @@
   </PropertyGroup>
   <PropertyGroup>
     <StartupObject>FlashEditor.FlashEditorForm</StartupObject>
+    <GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="1.0.3" PrivateAssets="all" />
+    <Reference Include="System.Resources.Extensions">
+      <HintPath>..\packages\System.Resources.Extensions.7.0.0\lib\net462\System.Resources.Extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <PropertyGroup>
     <ApplicationIcon>

--- a/FlashEditor/packages.config
+++ b/FlashEditor/packages.config
@@ -7,4 +7,6 @@
   <package id="ObjectListView.Official" version="2.9.1" targetFramework="net472" />
   <package id="OpenTK" version="3.3.1" targetFramework="net472" />
   <package id="SharpZipLib" version="1.3.2" targetFramework="net472" />
+  <package id="IKVM" version="8.1.5717" targetFramework="net472" />
+  <package id="System.Resources.Extensions" version="7.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
## Summary
- mark test project as an actual test project
- add Microsoft.NET.Test.Sdk dependency
- compile FlashEditor with newer language version
- add System.Resources.Extensions assembly reference
- restore IKVM and System.Resources.Extensions packages

## Testing
- `dotnet restore FlashEditor.sln --packages ./packages`
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj -v minimal` *(fails: Could not load Microsoft.VisualStudio.TestPlatform.ObjectModel)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b8d38ac832d888077249114ee7e