### PR TITLE
Improve codec unit tests

### DIFF
--- a/FlashEditor.Tests/Cache/CodecTests.cs
+++ b/FlashEditor.Tests/Cache/CodecTests.cs
@@ -1,5 +1,6 @@
 using FlashEditor;
 using FlashEditor.cache;
+using FlashEditor.utils;
 using System.Collections.Generic;
 using Xunit;
 
@@ -7,6 +8,11 @@ namespace FlashEditor.Tests.Cache
 {
     public class CodecTests
     {
+        public CodecTests()
+        {
+            // Disable blocking debug prompts during test execution
+            DebugUtil.LOG_LEVEL = DebugUtil.LOG_DETAIL.NONE;
+        }
         [Fact]
         public void ReferenceTable_EncodeDecode_RoundTrips()
         {


### PR DESCRIPTION
## Summary
- disable DebugUtil prompts in codec tests so they can run unattended

## Testing
- `dotnet test` *(fails: BrightIdeasSoftware not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7b720af4832d8b5cca3d9c308a69