### PR TITLE
Refactor for performance

### DIFF
--- a/FlashEditor/Cache/RSFileStore.cs
+++ b/FlashEditor/Cache/RSFileStore.cs
@@ -55,7 +55,12 @@ namespace FlashEditor.cache {
                 throw new NullReferenceException("IndexChannels is null");
 
             //Don't include the meta index as a type, of course
-            return indexChannels.Keys.Where(x => x < RSConstants.META_INDEX).Max();
+            int max = 0;
+            foreach(int key in indexChannels.Keys) {
+                if(key < RSConstants.META_INDEX && key > max)
+                    max = key;
+            }
+            return max;
         }
 
         internal RSIndex GetIndex(int type) {

--- a/FlashEditor/Collections/ArrayUtil.cs
+++ b/FlashEditor/Collections/ArrayUtil.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace FlashEditor.Collections {
     public static class ArrayUtil {
@@ -13,7 +12,10 @@ namespace FlashEditor.Collections {
         /// <returns></returns>
         public static T[][] ReturnRectangularArray<T>(int firstDimension, int secondDimension)
             where T : struct {
-            return new T[firstDimension].Select(obj => new T[secondDimension]).ToArray();
+            T[][] result = new T[firstDimension][];
+            for(int i = 0; i < firstDimension; i++)
+                result[i] = new T[secondDimension];
+            return result;
         }
     }
 }

--- a/FlashEditor/Definitions/ItemDefinition.cs
+++ b/FlashEditor/Definitions/ItemDefinition.cs
@@ -114,185 +114,205 @@ namespace FlashEditor {
         /// <param name="stream">The stream to read from</param>
         /// <param name="opcode">The opcode value signalling which type to read</param>
         private void Decode(JagStream stream, int opcode) {
-            if(opcode == 1) {
-                inventoryModelId = stream.ReadUnsignedShort();
-            } else if(opcode == 2) {
-                name = stream.ReadJagexString();
-            } else if(opcode == 4) {
-                modelZoom = stream.ReadUnsignedShort();
-            } else if(opcode == 5) {
-                modelRotation1 = stream.ReadUnsignedShort();
-            } else if(opcode == 6) {
-                modelRotation2 = stream.ReadUnsignedShort();
-            } else if(opcode == 7) {
-                modelOffset1 = stream.ReadUnsignedShort();
-                if(modelOffset1 > 32767)
-                    modelOffset1 -= 65536;
-                modelOffset1 <<= 0;
-            } else if(opcode == 8) {
-                modelOffset2 = stream.ReadUnsignedShort();
-                if(modelOffset2 > 32767)
-                    modelOffset2 -= 65536;
-                modelOffset2 <<= 0;
-            } else if(opcode == 11) {
-                stackable = 1;
-            } else if(opcode == 12) {
-                value = stream.ReadInt();
-            } else if(opcode == 13) {
-                equipSlotId = stream.ReadUnsignedByte();
-            } else if(opcode == 14) {
-                equipId = stream.ReadUnsignedByte();
-            } else if(opcode == 16) {
-                membersOnly = true;
-            } else if(opcode == 18) {
-                multiStackSize = stream.ReadUnsignedShort();
-            } else if(opcode == 23) {
-                maleWearModel1 = stream.ReadUnsignedShort();
-            } else if(opcode == 24) {
-                femaleWearModel1 = stream.ReadUnsignedShort();
-            } else if(opcode == 25) {
-                maleWearModel2 = stream.ReadUnsignedShort();
-            } else if(opcode == 26) {
-                femaleWearModel2 = stream.ReadUnsignedShort();
-            } else if(opcode == 27) {
-                stream.ReadUnsignedByte();
-            } else if(opcode >= 30 && opcode < 35) {
-                groundOptions[opcode - 30] = stream.ReadJagexString();
-                if(groundOptions[opcode - 30].Equals("Hidden", StringComparison.InvariantCultureIgnoreCase))
-                    groundOptions[opcode - 30] = null;
-            } else if(opcode >= 35 && opcode < 40) {
-                inventoryOptions[opcode - 35] = stream.ReadJagexString();
-            } else if(opcode == 40) {
-                int length = stream.ReadUnsignedByte();
-                originalModelColors = new short[length];
-                modifiedModelColors = new short[length];
-                for(int index = 0; index < length; index++) {
-                    originalModelColors[index] = unchecked((short) (stream.ReadUnsignedShort()));
-                    modifiedModelColors[index] = unchecked((short) (stream.ReadUnsignedShort()));
-                }
-            } else if(opcode == 41) {
-                int length = stream.ReadUnsignedByte();
-                textureColour1 = new short[length];
-                textureColour2 = new short[length];
-                for(int index = 0; index < length; index++) {
-                    textureColour1[index] = unchecked((short) (stream.ReadUnsignedShort()));
-                    textureColour2[index] = unchecked((short) (stream.ReadUnsignedShort()));
-                }
-            } else if(opcode == 42) {
-                int length = stream.ReadUnsignedByte();
-                for(int index = 0; index < length; index++)
-                    stream.ReadByte();
-            } else if(opcode == 43) {
-                nameColor = stream.ReadInt();
-                hasNameColor = true;
-            } else if(opcode == 44) {
-                stream.ReadUnsignedShort();
-                //There's more crap but for the moment it's unnecessary
-            } else if(opcode == 45) { //idk
-                stream.ReadUnsignedShort();
-                //As above
-            } else if(opcode == 65) {
-                unnoted = true;
-            } else if(opcode == 78) {
-                colourEquip1 = stream.ReadUnsignedShort();
-            } else if(opcode == 79) {
-                colourEquip2 = stream.ReadUnsignedShort();
-            } else if(opcode == 90) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 91) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 92) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 93) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 94) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 95) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 96) {
-                stream.ReadUnsignedByte();
-            } else if(opcode == 97) {
-                notedId = stream.ReadUnsignedShort();
-            } else if(opcode == 98) {
-                notedTemplateId = stream.ReadUnsignedShort();
-            } else if(opcode >= 100 && opcode < 110) {
-                if(stackableIds == null) {
-                    stackableIds = new int[10];
-                    stackableAmounts = new int[10];
-                }
-                stackableIds[opcode - 100] = stream.ReadUnsignedShort();
-                stackableAmounts[opcode - 100] = stream.ReadUnsignedShort();
-            } else if(opcode == 110) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 111) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 112) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 113) {
-                ambient = stream.ReadUnsignedByte();
-            } else if(opcode == 114) {
-                contrast = stream.ReadUnsignedByte();
-            } else if(opcode == 115) {
-                teamId = stream.ReadUnsignedByte();
-            } else if(opcode == 121) {
-                lendId = stream.ReadUnsignedShort();
-            } else if(opcode == 122) {
-                lendTemplateId = stream.ReadUnsignedShort();
-            } else if(opcode == 125) {
-                manWearXOffset = stream.ReadUnsignedByte() << 2;
-                manWearYOffset = stream.ReadUnsignedByte() << 2;
-                manWearZOffset = stream.ReadUnsignedByte() << 2;
-            } else if(opcode == 126) {
-                womanWearXOffset = stream.ReadUnsignedByte() << 0;
-                womanWearYOffset = stream.ReadUnsignedByte() << 0;
-                womanWearZOffset = stream.ReadUnsignedByte() << 0;
-            } else if(opcode == 127) {
-                int groupCursorOp = stream.ReadUnsignedByte();
-                int groundCursor = stream.ReadUnsignedShort();
-            } else if(opcode == 128) {
-                int cursor2op = stream.ReadUnsignedByte();
-                int cursor2 = stream.ReadUnsignedShort();
-            } else if(opcode == 129) {
-                int cursor2op = stream.ReadUnsignedByte();
-                int cursor2 = stream.ReadUnsignedShort();
-            } else if(opcode == 130) {
-                int cursor2iop = stream.ReadUnsignedByte();
-                int icursor2 = stream.ReadUnsignedShort();
-            } else if(opcode == 132) {
-                int length = stream.ReadUnsignedByte();
-                int[] unknownArray2 = new int[length];
-                for(int index = 0; index < length; index++)
-                    unknownArray2[index] = stream.ReadUnsignedShort();
-            } else if(opcode == 134) {
-                stream.ReadUnsignedByte();
-            } else if(opcode == 139) {
-                //bindLink
-                stream.ReadUnsignedShort();
-            } else if(opcode == 140) {
-                //bindTemplate
-                stream.ReadUnsignedShort();
-            } else if(opcode >= 142 && opcode < 147) {
-                stream.ReadUnsignedShort();
-            } else if(opcode >= 150 && opcode < 155) {
-                stream.ReadUnsignedShort();
-            } else if(opcode == 157) {
-                //some bool
-            } else if(opcode == 161) {
-                //shardLink
-                stream.ReadUnsignedShort();
-            } else if(opcode == 162) {
-                //shardTemplate
-                stream.ReadUnsignedShort();
-            } else if(opcode == 163) {
-                //shardCombineAmount
-                stream.ReadUnsignedShort();
-            } else if(opcode == 164) {
-                //shardName
-                stream.ReadJagexString();
-            } else if(opcode == 249) {
-                int length = stream.ReadUnsignedByte();
+            switch(opcode) {
+                case 1:
+                    inventoryModelId = stream.ReadUnsignedShort();
+                    break;
+                case 2:
+                    name = stream.ReadJagexString();
+                    break;
+                case 4:
+                    modelZoom = stream.ReadUnsignedShort();
+                    break;
+                case 5:
+                    modelRotation1 = stream.ReadUnsignedShort();
+                    break;
+                case 6:
+                    modelRotation2 = stream.ReadUnsignedShort();
+                    break;
+                case 7:
+                    modelOffset1 = stream.ReadUnsignedShort();
+                    if(modelOffset1 > 32767)
+                        modelOffset1 -= 65536;
+                    modelOffset1 <<= 0;
+                    break;
+                case 8:
+                    modelOffset2 = stream.ReadUnsignedShort();
+                    if(modelOffset2 > 32767)
+                        modelOffset2 -= 65536;
+                    modelOffset2 <<= 0;
+                    break;
+                case 11:
+                    stackable = 1;
+                    break;
+                case 12:
+                    value = stream.ReadInt();
+                    break;
+                case 13:
+                    equipSlotId = stream.ReadUnsignedByte();
+                    break;
+                case 14:
+                    equipId = stream.ReadUnsignedByte();
+                    break;
+                case 16:
+                    membersOnly = true;
+                    break;
+                case 18:
+                    multiStackSize = stream.ReadUnsignedShort();
+                    break;
+                case 23:
+                    maleWearModel1 = stream.ReadUnsignedShort();
+                    break;
+                case 24:
+                    femaleWearModel1 = stream.ReadUnsignedShort();
+                    break;
+                case 25:
+                    maleWearModel2 = stream.ReadUnsignedShort();
+                    break;
+                case 26:
+                    femaleWearModel2 = stream.ReadUnsignedShort();
+                    break;
+                case 27:
+                    stream.ReadUnsignedByte();
+                    break;
+                default:
+                    if(opcode >= 30 && opcode < 35) {
+                        groundOptions[opcode - 30] = stream.ReadJagexString();
+                        if(groundOptions[opcode - 30].Equals("Hidden", StringComparison.InvariantCultureIgnoreCase))
+                            groundOptions[opcode - 30] = null;
+                    } else if(opcode >= 35 && opcode < 40) {
+                        inventoryOptions[opcode - 35] = stream.ReadJagexString();
+                    } else if(opcode == 40) {
+                        int length = stream.ReadUnsignedByte();
+                        originalModelColors = new short[length];
+                        modifiedModelColors = new short[length];
+                        for(int index = 0; index < length; index++) {
+                            originalModelColors[index] = unchecked((short) (stream.ReadUnsignedShort()));
+                            modifiedModelColors[index] = unchecked((short) (stream.ReadUnsignedShort()));
+                        }
+                    } else if(opcode == 41) {
+                        int length = stream.ReadUnsignedByte();
+                        textureColour1 = new short[length];
+                        textureColour2 = new short[length];
+                        for(int index = 0; index < length; index++) {
+                            textureColour1[index] = unchecked((short) (stream.ReadUnsignedShort()));
+                            textureColour2[index] = unchecked((short) (stream.ReadUnsignedShort()));
+                        }
+                    } else if(opcode == 42) {
+                        int length = stream.ReadUnsignedByte();
+                        for(int index = 0; index < length; index++)
+                            stream.ReadByte();
+                    } else if(opcode == 43) {
+                        nameColor = stream.ReadInt();
+                        hasNameColor = true;
+                    } else if(opcode == 44) {
+                        stream.ReadUnsignedShort();
+                        //There's more crap but for the moment it's unnecessary
+                    } else if(opcode == 45) { //idk
+                        stream.ReadUnsignedShort();
+                        //As above
+                    } else if(opcode == 65) {
+                        unnoted = true;
+                    } else if(opcode == 78) {
+                        colourEquip1 = stream.ReadUnsignedShort();
+                    } else if(opcode == 79) {
+                        colourEquip2 = stream.ReadUnsignedShort();
+                    } else if(opcode == 90) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 91) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 92) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 93) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 94) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 95) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 96) {
+                        stream.ReadUnsignedByte();
+                    } else if(opcode == 97) {
+                        notedId = stream.ReadUnsignedShort();
+                    } else if(opcode == 98) {
+                        notedTemplateId = stream.ReadUnsignedShort();
+                    } else if(opcode >= 100 && opcode < 110) {
+                        if(stackableIds == null) {
+                            stackableIds = new int[10];
+                            stackableAmounts = new int[10];
+                        }
+                        stackableIds[opcode - 100] = stream.ReadUnsignedShort();
+                        stackableAmounts[opcode - 100] = stream.ReadUnsignedShort();
+                    } else if(opcode == 110) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 111) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 112) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 113) {
+                        ambient = stream.ReadUnsignedByte();
+                    } else if(opcode == 114) {
+                        contrast = stream.ReadUnsignedByte();
+                    } else if(opcode == 115) {
+                        teamId = stream.ReadUnsignedByte();
+                    } else if(opcode == 121) {
+                        lendId = stream.ReadUnsignedShort();
+                    } else if(opcode == 122) {
+                        lendTemplateId = stream.ReadUnsignedShort();
+                    } else if(opcode == 125) {
+                        manWearXOffset = stream.ReadUnsignedByte() << 2;
+                        manWearYOffset = stream.ReadUnsignedByte() << 2;
+                        manWearZOffset = stream.ReadUnsignedByte() << 2;
+                    } else if(opcode == 126) {
+                        womanWearXOffset = stream.ReadUnsignedByte() << 0;
+                        womanWearYOffset = stream.ReadUnsignedByte() << 0;
+                        womanWearZOffset = stream.ReadUnsignedByte() << 0;
+                    } else if(opcode == 127) {
+                        int groupCursorOp = stream.ReadUnsignedByte();
+                        int groundCursor = stream.ReadUnsignedShort();
+                    } else if(opcode == 128) {
+                        int cursor2op = stream.ReadUnsignedByte();
+                        int cursor2 = stream.ReadUnsignedShort();
+                    } else if(opcode == 129) {
+                        int cursor2op = stream.ReadUnsignedByte();
+                        int cursor2 = stream.ReadUnsignedShort();
+                    } else if(opcode == 130) {
+                        int cursor2iop = stream.ReadUnsignedByte();
+                        int icursor2 = stream.ReadUnsignedShort();
+                    } else if(opcode == 132) {
+                        int length = stream.ReadUnsignedByte();
+                        int[] unknownArray2 = new int[length];
+                        for(int index = 0; index < length; index++)
+                            unknownArray2[index] = stream.ReadUnsignedShort();
+                    } else if(opcode == 134) {
+                        stream.ReadUnsignedByte();
+                    } else if(opcode == 139) {
+                        //bindLink
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 140) {
+                        //bindTemplate
+                        stream.ReadUnsignedShort();
+                    } else if(opcode >= 142 && opcode < 147) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode >= 150 && opcode < 155) {
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 157) {
+                        //some bool
+                    } else if(opcode == 161) {
+                        //shardLink
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 162) {
+                        //shardTemplate
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 163) {
+                        //shardCombineAmount
+                        stream.ReadUnsignedShort();
+                    } else if(opcode == 164) {
+                        //shardName
+                        stream.ReadJagexString();
+                    } else if(opcode == 249) {
+                        int length = stream.ReadUnsignedByte();
 
-                itemParams = new SortedDictionary<int, object>();
+                        itemParams = new SortedDictionary<int, object>();
 
                 for(int k = 0; k < length; k++) {
                     bool stringInstance = stream.ReadUnsignedByte() == 1;
@@ -308,7 +328,9 @@ namespace FlashEditor {
                             itemParams.Add(key, x);
                     }
                 }
+                    break;
             }
+        }
         }
 
         /// <summary>

--- a/FlashEditor/Definitions/Models/ModelDefinition.cs
+++ b/FlashEditor/Definitions/Models/ModelDefinition.cs
@@ -69,30 +69,37 @@ namespace FlashEditor.Definitions.Model {
                     float f8 = f2 * (-f1 + 1.0F);
                     float f9 = f2 * (-(f7 * f1) + 1.0F);
                     float f10 = (1.0F - f1 * (-f7 + 1.0F)) * f2;
-                    if(i4 == 0) {
-                        f3 = f2;
-                        f5 = f8;
-                        f4 = f10;
-                    } else if(i4 == 1) {
-                        f5 = f8;
-                        f3 = f9;
-                        f4 = f2;
-                    } else if(i4 == 2) {
-                        f3 = f8;
-                        f4 = f2;
-                        f5 = f10;
-                    } else if(i4 == 3) {
-                        f4 = f9;
-                        f3 = f8;
-                        f5 = f2;
-                    } else if(i4 == 4) {
-                        f5 = f2;
-                        f3 = f10;
-                        f4 = f8;
-                    } else {
-                        f4 = f8;
-                        f5 = f9;
-                        f3 = f2;
+                    switch(i4) {
+                        case 0:
+                            f3 = f2;
+                            f5 = f8;
+                            f4 = f10;
+                            break;
+                        case 1:
+                            f5 = f8;
+                            f3 = f9;
+                            f4 = f2;
+                            break;
+                        case 2:
+                            f3 = f8;
+                            f4 = f2;
+                            f5 = f10;
+                            break;
+                        case 3:
+                            f4 = f9;
+                            f3 = f8;
+                            f5 = f2;
+                            break;
+                        case 4:
+                            f5 = f2;
+                            f3 = f10;
+                            f4 = f8;
+                            break;
+                        default:
+                            f4 = f8;
+                            f5 = f9;
+                            f3 = f2;
+                            break;
                     }
 
                     out1[i++] = (int) ((float) Math.Pow((double) f3, d) * 256.0F) << 16

--- a/FlashEditor/Definitions/Tracks/Track.cs
+++ b/FlashEditor/Definitions/Tracks/Track.cs
@@ -102,30 +102,43 @@ namespace FlashEditor.Definitions.Tracks {
             for(var29 = 0; var29 < ctrlChangeOpcodes; ++var29) {
                 var28 = var28 + (buf.ReadUnsignedByte()) & 127;
                 if(var28 != 0 && var28 != 32) {
-                    if(var28 == 1) {
-                        ++var16;
-                    } else if(var28 == 33) {
-                        ++var17;
-                    } else if(var28 == 7) {
-                        ++var18;
-                    } else if(var28 == 39) {
-                        ++var19;
-                    } else if(var28 == 10) {
-                        ++var20;
-                    } else if(var28 == 42) {
-                        ++var21;
-                    } else if(var28 == 99) {
-                        ++var22;
-                    } else if(var28 == 98) {
-                        ++var23;
-                    } else if(var28 == 101) {
-                        ++var24;
-                    } else if(var28 == 100) {
-                        ++var25;
-                    } else if(var28 != 64 && var28 != 65 && var28 != 120 && var28 != 121 && var28 != 123) {
-                        ++var27;
-                    } else {
-                        ++var26;
+                    switch(var28) {
+                        case 1:
+                            ++var16;
+                            break;
+                        case 33:
+                            ++var17;
+                            break;
+                        case 7:
+                            ++var18;
+                            break;
+                        case 39:
+                            ++var19;
+                            break;
+                        case 10:
+                            ++var20;
+                            break;
+                        case 42:
+                            ++var21;
+                            break;
+                        case 99:
+                            ++var22;
+                            break;
+                        case 98:
+                            ++var23;
+                            break;
+                        case 101:
+                            ++var24;
+                            break;
+                        case 100:
+                            ++var25;
+                            break;
+                        default:
+                            if(var28 != 64 && var28 != 65 && var28 != 120 && var28 != 121 && var28 != 123)
+                                ++var27;
+                            else
+                                ++var26;
+                            break;
                     }
                 } else {
                     ++progmChangeOpcodes;
@@ -260,7 +273,8 @@ label361:
                         midiBuff.WriteByte((byte) buf.ToArray()[var50++]);
                     } else {
                         var52 ^= var64 >> 4;
-                        if(var62 == 0) {
+                        switch(var62) {
+                        case 0:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (144 + var52));
                             }
@@ -269,7 +283,8 @@ label361:
                             var54 += buf.ToArray()[var38++];
                             midiBuff.WriteByte((byte) (var53 & 127));
                             midiBuff.WriteByte((byte) (var54 & 127));
-                        } else if(var62 == 1) {
+                            break;
+                        case 1:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (128 + var52));
                             }
@@ -278,7 +293,8 @@ label361:
                             var55 += buf.ToArray()[var40++];
                             midiBuff.WriteByte((byte) (var53 & 127));
                             midiBuff.WriteByte((byte) (var55 & 127));
-                        } else if(var62 == 2) {
+                            break;
+                        case 2:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (176 + var52));
                             }
@@ -319,7 +335,8 @@ label361:
                             int var67 = var66 + var59[var28];
                             var59[var28] = var67;
                             midiBuff.WriteByte((byte) (var67 & 127));
-                        } else if(var62 == 3) {
+                            break;
+                        case 3:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (224 + var52));
                             }
@@ -328,14 +345,16 @@ label361:
                             var56 += buf.ToArray()[var33++] << 7;
                             midiBuff.WriteByte((byte) (var56 & 127));
                             midiBuff.WriteByte((byte) (var56 >> 7 & 127));
-                        } else if(var62 == 4) {
+                            break;
+                        case 4:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (208 + var52));
                             }
 
                             var57 += buf.ToArray()[var32++];
                             midiBuff.WriteByte((byte) (var57 & 127));
-                        } else if(var62 == 5) {
+                            break;
+                        case 5:
                             if(var65) {
                                 midiBuff.WriteByte((byte) (160 + var52));
                             }
@@ -344,7 +363,8 @@ label361:
                             var58 += buf.ToArray()[var31++];
                             midiBuff.WriteByte((byte) (var53 & 127));
                             midiBuff.WriteByte((byte) (var58 & 127));
-                        } else {
+                            break;
+                        default:
                             if(var62 != 6)
                                 throw new Exception();
 
@@ -352,6 +372,7 @@ label361:
                                 midiBuff.WriteByte((byte) (192 + var52));
 
                             midiBuff.WriteByte((byte) buf.ToArray()[var44++]);
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- swap large opcode `if/else` chains for `switch` statements
- remove LINQ from `ArrayUtil` and `RSFileStore`
- convert small conditional block in `ModelDefinition` to `switch`
- do the same for MIDI `Track` decoding

## Testing
- `dotnet test --no-build` *(fails: .NET Framework 4.7.2 not available)*

------
https://chatgpt.com/codex/tasks/task_e_684e7f98694c832d9044a65dcbcd04aa