### PR TITLE
Make cache classes public for tests

### DIFF
--- a/FlashEditor/Cache/RSArchive.cs
+++ b/FlashEditor/Cache/RSArchive.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using static FlashEditor.utils.DebugUtil;
 
 namespace FlashEditor.cache {
-    class RSArchive {
+    public class RSArchive {
         public SortedDictionary<int, JagStream> entries = new SortedDictionary<int, JagStream>();
         public int chunks = 1;
 
@@ -133,7 +133,7 @@ namespace FlashEditor.cache {
             return entries.Count;
         }
 
-        internal void PutEntry(int entryId, JagStream entry) {
+        public void PutEntry(int entryId, JagStream entry) {
             if(entries.ContainsKey(entryId)) {
                 //Update the entry
                 entries[entryId] = entry;

--- a/FlashEditor/Cache/RSContainer.cs
+++ b/FlashEditor/Cache/RSContainer.cs
@@ -4,7 +4,7 @@ using System;
 using FlashEditor.utils;
 
 namespace FlashEditor.cache {
-    internal class RSContainer {
+    public class RSContainer {
         private JagStream stream; //the archive stream
         public int type;
         public int id;

--- a/FlashEditor/Cache/RSEntry.cs
+++ b/FlashEditor/Cache/RSEntry.cs
@@ -116,15 +116,15 @@ namespace FlashEditor.cache {
             return hash;
         }
 
-        internal void SetValidFileIds(int[] validFileIds) {
+        public void SetValidFileIds(int[] validFileIds) {
             this.validFileIds = validFileIds;
         }
 
-        internal int[] GetValidFileIds() {
+        public int[] GetValidFileIds() {
             return validFileIds;
         }
 
-        internal void SetChildEntries(SortedDictionary<int, RSChildEntry> childEntries) {
+        public void SetChildEntries(SortedDictionary<int, RSChildEntry> childEntries) {
             this.childEntries = childEntries;
         }
 

--- a/FlashEditor/Cache/RSReferenceTable.cs
+++ b/FlashEditor/Cache/RSReferenceTable.cs
@@ -144,7 +144,7 @@ namespace FlashEditor.cache {
             return table;
         }
 
-        internal void PutEntry(int containerId, RSEntry entry) {
+        public void PutEntry(int containerId, RSEntry entry) {
             if(entries.ContainsKey(containerId))
                 entries[containerId] = entry;
             else

--- a/FlashEditor/Utils/Debugging.cs
+++ b/FlashEditor/Utils/Debugging.cs
@@ -49,7 +49,7 @@ namespace FlashEditor.utils {
         /// Prints out the entire byte array separated by spaces
         /// </summary>
         /// <param name="buffer">The byte buffer to print</param>
-        internal static void PrintByteArray(byte[] buffer) {
+        public static void PrintByteArray(byte[] buffer) {
             PrintByteArray(buffer, buffer.Length);
         }
 


### PR DESCRIPTION
## Summary
- expose container and archive APIs
- expose entry and reference table modifiers
- expose DebugUtil.PrintByteArray overload

## Testing
- `dotnet build -property:EnableWindowsTargeting=true`
- `dotnet test -property:EnableWindowsTargeting=true` *(fails: missing Microsoft.WindowsDesktop.App)*

------
https://chatgpt.com/codex/tasks/task_e_684e9e922db0832d9b5e3321d29e65f1