### PR TITLE
Fix visibility for test access

### DIFF
--- a/FlashEditor/Cache/RSArchive.cs
+++ b/FlashEditor/Cache/RSArchive.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using static FlashEditor.utils.DebugUtil;
 
 namespace FlashEditor.cache {
-    class RSArchive {
+    public class RSArchive {
         public SortedDictionary<int, JagStream> entries = new SortedDictionary<int, JagStream>();
         public int chunks = 1;
 
@@ -133,7 +133,7 @@ namespace FlashEditor.cache {
             return entries.Count;
         }
 
-        internal void PutEntry(int entryId, JagStream entry) {
+        public void PutEntry(int entryId, JagStream entry) {
             if(entries.ContainsKey(entryId)) {
                 //Update the entry
                 entries[entryId] = entry;

--- a/FlashEditor/Cache/RSContainer.cs
+++ b/FlashEditor/Cache/RSContainer.cs
@@ -4,7 +4,7 @@ using System;
 using FlashEditor.utils;
 
 namespace FlashEditor.cache {
-    internal class RSContainer {
+    public class RSContainer {
         private JagStream stream; //the archive stream
         public int type;
         public int id;

--- a/FlashEditor/Cache/RSEntry.cs
+++ b/FlashEditor/Cache/RSEntry.cs
@@ -116,7 +116,7 @@ namespace FlashEditor.cache {
             return hash;
         }
 
-        internal void SetValidFileIds(int[] validFileIds) {
+        public void SetValidFileIds(int[] validFileIds) {
             this.validFileIds = validFileIds;
         }
 
@@ -124,7 +124,7 @@ namespace FlashEditor.cache {
             return validFileIds;
         }
 
-        internal void SetChildEntries(SortedDictionary<int, RSChildEntry> childEntries) {
+        public void SetChildEntries(SortedDictionary<int, RSChildEntry> childEntries) {
             this.childEntries = childEntries;
         }
 

--- a/FlashEditor/Cache/RSReferenceTable.cs
+++ b/FlashEditor/Cache/RSReferenceTable.cs
@@ -144,7 +144,7 @@ namespace FlashEditor.cache {
             return table;
         }
 
-        internal void PutEntry(int containerId, RSEntry entry) {
+        public void PutEntry(int containerId, RSEntry entry) {
             if(entries.ContainsKey(containerId))
                 entries[containerId] = entry;
             else

--- a/FlashEditor/Utils/Debugging.cs
+++ b/FlashEditor/Utils/Debugging.cs
@@ -49,7 +49,7 @@ namespace FlashEditor.utils {
         /// Prints out the entire byte array separated by spaces
         /// </summary>
         /// <param name="buffer">The byte buffer to print</param>
-        internal static void PrintByteArray(byte[] buffer) {
+        public static void PrintByteArray(byte[] buffer) {
             PrintByteArray(buffer, buffer.Length);
         }
 


### PR DESCRIPTION
## Summary
- expose RSContainer and RSArchive classes
- allow tests to use RSEntry and RSReferenceTable helpers
- make DebugUtil.PrintByteArray public for unit tests

## Testing
- `dotnet test FlashEditor.sln -c Release -p:EnableWindowsTargeting=true` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e9fda2a3c832dbed321b3957a0a52