### PR TITLE
Ensure LOG_LEVEL=NONE disables debug output

### DIFF
--- a/FlashEditor/Definitions/Models/ModelDefinition.cs
+++ b/FlashEditor/Definitions/Models/ModelDefinition.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using OpenTK;
+using static FlashEditor.utils.DebugUtil;
 
 namespace FlashEditor.Definitions.Model {
 
@@ -916,7 +917,7 @@ namespace FlashEditor.Definitions.Model {
 
             int i = footer.ReadUnsignedByte();
             if(i != 1)
-                Console.WriteLine(i);
+                Debug(i.ToString());
             else {
                 footer.ReadUnsignedByte();// dummy read in
                 version = footer.ReadUnsignedByte();// version now reads here instead
@@ -1395,7 +1396,7 @@ namespace FlashEditor.Definitions.Model {
             JagStream class219_sub41_140_ = new JagStream((byte[])(Array)instream);
             int i = footer.ReadUnsignedByte();
             if(i != 0)
-                Console.WriteLine(i);
+                Debug(i.ToString());
             else {
                 footer.Position = (instream.Length - 18);
                 numVertices = footer.ReadUnsignedShort();
@@ -1636,7 +1637,7 @@ namespace FlashEditor.Definitions.Model {
             JagStream var8 = new JagStream((byte[])(Array)data);
             int modelType = header.ReadUnsignedByte();
             if(modelType != 1) {
-                Console.WriteLine("" + modelType);
+                Debug("" + modelType);
             } else {
                 header.ReadUnsignedByte();
                 this.version = header.ReadUnsignedByte();

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -268,7 +268,7 @@ namespace FlashEditor {
                         int percentile = total / 100;
 
                         bgw.ReportProgress(0, "Loading " + total + " Sprites");
-                        System.Console.WriteLine("Loading " + total + " Sprites");
+                        Debug("Loading " + total + " Sprites");
                         foreach(KeyValuePair<int, RSEntry> entry in referenceTable.GetEntries()) {
                             try {
                                 Debug("Loading sprite: " + entry.Key, LOG_DETAIL.ADVANCED);

--- a/FlashEditor/Utils/Debugging.cs
+++ b/FlashEditor/Utils/Debugging.cs
@@ -23,6 +23,9 @@ namespace FlashEditor.utils {
         /// </summary>
         /// <param name="output">The debug message</param>
         public static void Debug(string output) {
+            if(LOG_LEVEL == LOG_DETAIL.NONE)
+                return;
+
             Console.WriteLine(output);
         }
 
@@ -59,6 +62,9 @@ namespace FlashEditor.utils {
         /// <param name="buffer">The byte buffer to print</param>
         /// <param name="length">The number of bytes to print from the beginning and end of the buffer</param>
         public static void PrintByteArray(byte[] buffer, int length) {
+            if(LOG_LEVEL == LOG_DETAIL.NONE)
+                return;
+
             //We cannot print more than max bytes on either side
             int max = 20; //buffer.Length;
 
@@ -81,6 +87,9 @@ namespace FlashEditor.utils {
         }
 
         public static void WriteLine(string output) {
+            if(LOG_LEVEL == LOG_DETAIL.NONE)
+                return;
+
             Console.WriteLine(output);
         }
 


### PR DESCRIPTION
## Summary
- gate `DebugUtil.Debug` and related helpers behind `LOG_LEVEL`
- remove direct `Console.WriteLine` calls from `Editor` and `ModelDefinition`
- add `DebugUtil` import to `ModelDefinition` to use the logging helpers

## Testing
- `dotnet test --no-build` *(fails: Build succeeded but no tests executed)*

------
https://chatgpt.com/codex/tasks/task_e_684ea56fd234832da7e418b1ea47f45e