### PR TITLE
Improve I/O buffering and use memory mapping

### DIFF
--- a/FlashEditor/Cache/RSFileStore.cs
+++ b/FlashEditor/Cache/RSFileStore.cs
@@ -43,7 +43,7 @@ namespace FlashEditor.cache {
         /// <param name="stream">The stream (reference) to read the data into</param>
         /// <param name="directory">The directory of the binary file</param>
         private RSIndex LoadIndex(string directory) {
-            return new RSIndex(JagStream.LoadStream(directory));
+            return new RSIndex(JagStream.LoadMappedStream(directory));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- buffer file reads in `JagStream.LoadStream`
- add `JagStream.LoadMappedStream` to use `MemoryMappedFile`
- use the new mapped load in `RSFileStore`

## Testing
- `dotnet restore /p:EnableWindowsTargeting=true`
- `dotnet build /p:EnableWindowsTargeting=true` *(fails: RSEntry/RSArchive API issues)*
- `dotnet test /p:EnableWindowsTargeting=true` *(fails to run due to missing framework)*

------
https://chatgpt.com/codex/tasks/task_e_684ea7839a34832d80120d4055235db7