### PR TITLE
Replace if/else logic with switch expressions

### DIFF
--- a/FlashEditor/Cache/RSContainer.cs
+++ b/FlashEditor/Cache/RSContainer.cs
@@ -46,13 +46,12 @@ namespace FlashEditor.cache {
             int oldLen = data.Length;
 
             //Write the data to the stream
-            if(GetCompressionType() == RSConstants.BZIP2_COMPRESSION) {
-                data = CompressionUtils.Bzip2(data);
-                compressionType = RSConstants.BZIP2_COMPRESSION;
-            } else if(GetCompressionType() == RSConstants.GZIP_COMPRESSION) {
-                data = CompressionUtils.Gzip(data);
-                compressionType = RSConstants.GZIP_COMPRESSION;
-            }
+            compressionType = GetCompressionType();
+            data = compressionType switch {
+                RSConstants.BZIP2_COMPRESSION => CompressionUtils.Bzip2(data),
+                RSConstants.GZIP_COMPRESSION => CompressionUtils.Gzip(data),
+                _ => data
+            };
 
             Debug("Compressed " + oldLen + " to : " + data.Length);
 
@@ -124,12 +123,11 @@ namespace FlashEditor.cache {
                 stream.Read(data, 0, data.Length);
 
                 //Decompress the data
-                if(container.GetCompressionType() == RSConstants.BZIP2_COMPRESSION)
-                    data = CompressionUtils.Bunzip2(data, container.GetDecompressedLength());
-                else if(container.GetCompressionType() == RSConstants.GZIP_COMPRESSION)
-                    data = CompressionUtils.Gunzip(data);
-                else
-                    throw new IOException("Invalid compression type");
+                data = container.GetCompressionType() switch {
+                    RSConstants.BZIP2_COMPRESSION => CompressionUtils.Bunzip2(data, container.GetDecompressedLength()),
+                    RSConstants.GZIP_COMPRESSION => CompressionUtils.Gunzip(data),
+                    _ => throw new IOException("Invalid compression type")
+                };
 
                 //Check if the decompressed length is what it should be
                 if(data.Length != container.GetDecompressedLength())
@@ -143,12 +141,11 @@ namespace FlashEditor.cache {
         }
 
         public string GetCompressionString() {
-            string compressType = "None";
-            if(GetCompressionType() == RSConstants.BZIP2_COMPRESSION)
-                compressType = "BZIP2";
-            else if(GetCompressionType() == RSConstants.GZIP_COMPRESSION)
-                compressType = "GZIP";
-            return compressType;
+            return GetCompressionType() switch {
+                RSConstants.BZIP2_COMPRESSION => "BZIP2",
+                RSConstants.GZIP_COMPRESSION => "GZIP",
+                _ => "None"
+            };
         }
 
         private int GetDecompressedLength() {

--- a/FlashEditor/Cache/Region/Region.cs
+++ b/FlashEditor/Cache/Region/Region.cs
@@ -47,33 +47,37 @@ namespace FlashEditor.Cache.Region {
                     for(int y = 0; y < 64; y++) {
                         while(true) {
                             int attribute = buf.ReadUnsignedByte();
-                            if(attribute == 0) {
-                                if(z == 0) {
-                                    //TODO Verify the height calculation was correctly ripped from client
-                                    tileHeights[0, x, y] = HeightCalc.Calculate(baseX, baseY, x, y) << 3;
-                                } else
-                                    tileHeights[z, x, y] = tileHeights[z - 1, x, y] - 240;
+                            switch(attribute) {
+                                case 0:
+                                    if(z == 0) {
+                                        //TODO Verify the height calculation was correctly ripped from client
+                                        tileHeights[0, x, y] = HeightCalc.Calculate(baseX, baseY, x, y) << 3;
+                                    } else {
+                                        tileHeights[z, x, y] = tileHeights[z - 1, x, y] - 240;
+                                    }
+                                    break;
+                                case 1:
+                                    int height = buf.ReadUnsignedByte();
+                                    if(height == 1)
+                                        height = 0;
 
-                                break;
-                            } else if(attribute == 1) {
-                                int height = buf.ReadUnsignedByte();
-                                if(height == 1)
-                                    height = 0;
+                                    if(z == 0)
+                                        tileHeights[0, x, y] = -height << 3;
+                                    else
+                                        tileHeights[z, x, y] = tileHeights[z - 1, x, y] - height << 3;
 
-                                if(z == 0)
-                                    tileHeights[0, x, y] = -height << 3;
-                                else
-                                    tileHeights[z, x, y] = tileHeights[z - 1, x, y] - height << 3;
-
-                                break;
-                            } else if(attribute <= 49) {
-                                overlayIds[z, x, y] = (byte) buf.ReadByte();
-                                overlayPaths[z, x, y] = (byte) ((attribute - 2) / 4);
-                                overlayRotations[z, x, y] = (byte) (attribute - 2 & 0x3);
-                            } else if(attribute <= 81) {
-                                renderRules[z, x, y] = (byte) (attribute - 49);
-                            } else {
-                                underlayIds[z, x, y] = (byte) (attribute - 81);
+                                    break;
+                                case <= 49:
+                                    overlayIds[z, x, y] = (byte) buf.ReadByte();
+                                    overlayPaths[z, x, y] = (byte) ((attribute - 2) / 4);
+                                    overlayRotations[z, x, y] = (byte) (attribute - 2 & 0x3);
+                                    continue;
+                                case <= 81:
+                                    renderRules[z, x, y] = (byte) (attribute - 49);
+                                    continue;
+                                default:
+                                    underlayIds[z, x, y] = (byte) (attribute - 81);
+                                    continue;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- refactor compression logic with switch expressions
- convert terrain attribute checks to a switch

## Testing
- `dotnet test --no-build` *(fails: Build succeeded but tests did not run)*

------
https://chatgpt.com/codex/tasks/task_e_684ea78abfd4832d9e64c06f1777a3ea