### PR TITLE
Optimize parser buffers

### DIFF
--- a/FlashEditor/Cache/RSArchive.cs
+++ b/FlashEditor/Cache/RSArchive.cs
@@ -66,18 +66,16 @@ namespace FlashEditor.cache {
             //Return the stream to 0 otherwise this shit doesn't work
             stream.Seek0();
 
-            //Read the data into the buffers 
+            //Read the data into the buffers
             for(int chunk = 0; chunk < archive.chunks; chunk++) {
                 for(int id = 0; id < size; id++) {
                     //Get the length of this chunk
                     int chunkSize = chunkSizes[chunk][id];
 
-                    //Copy this chunk into a temporary buffer
-                    byte[] temp = new byte[chunkSize];
-                    stream.Read(temp, 0, temp.Length);
+                    Span<byte> temp = chunkSize <= 4096 ? stackalloc byte[chunkSize] : new byte[chunkSize];
+                    stream.Read(temp);
 
-                    //Copy the temporary buffer into the file buffer
-                    archive.entries[id].Write(temp, 0, temp.Length);
+                    archive.entries[id].Write(temp);
                 }
             }
 

--- a/FlashEditor/Cache/RSContainer.cs
+++ b/FlashEditor/Cache/RSContainer.cs
@@ -106,9 +106,10 @@ namespace FlashEditor.cache {
 
             if(container.GetCompressionType() == RSConstants.NO_COMPRESSION) {
                 //Simply grab the data and wrap it in a buffer
-                byte[] temp = new byte[container.GetDataLength()];
-                stream.Read(temp, 0, container.GetDataLength());
-                container.SetStream(new JagStream(temp));
+                int len = container.GetDataLength();
+                Span<byte> temp = len <= 4096 ? stackalloc byte[len] : new byte[len];
+                stream.Read(temp);
+                container.SetStream(new JagStream(temp.ToArray()));
 
                 container.SetVersion(stream.Remaining() >= 2 ? stream.ReadUnsignedShort() : -1); //Decode the version if present
                 container.PrintInfo();
@@ -121,7 +122,7 @@ namespace FlashEditor.cache {
 
                 //Read the data from the stream into a buffer
                 byte[] data = new byte[container.GetDataLength()];
-                stream.Read(data, 0, data.Length);
+                stream.Read(data.AsSpan());
 
                 //Decompress the data
                 if(container.GetCompressionType() == RSConstants.BZIP2_COMPRESSION)


### PR DESCRIPTION
## Summary
- use `Span<byte>` and `stackalloc` for JagStream array helpers
- avoid heap allocations when reading archives and containers
- reduce temporary arrays in checksum table
- rent buffers in compression helpers

## Testing
- `dotnet build FlashEditor/FlashEditor.csproj -c Release`
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj -c Release` *(fails: 'RSEntry' does not contain a definition for 'SetValidFileIds' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684ea78c83f4832d91df59a6ba4edd08