### PR TITLE
Optimize string handling

### DIFF
--- a/FlashEditor/Definitions/ItemDefinition.cs
+++ b/FlashEditor/Definitions/ItemDefinition.cs
@@ -61,6 +61,8 @@ namespace FlashEditor {
         public int equipId;
         public int multiStackSize;
 
+        private static readonly StringBuilder SharedBuilder = new StringBuilder();
+
         public SortedDictionary<int, object> itemParams;
 
         public ItemDefinition Clone() { return (ItemDefinition) MemberwiseClone(); }
@@ -77,7 +79,7 @@ namespace FlashEditor {
         public static ItemDefinition Decode(JagStream stream) {
             int total = 0;
 
-            StringBuilder sb = new StringBuilder();
+            SharedBuilder.Clear();
             ItemDefinition def = new ItemDefinition();
 
             if(stream != null) {
@@ -100,11 +102,11 @@ namespace FlashEditor {
 
                 for(int k = 0; k < def.decoded.Length; k++) {
                     if(def.decoded[k])
-                        sb.Append(k + " ");
+                        SharedBuilder.Append(k + " ");
                 }
             }
 
-            Debug((def.name ?? "null") + " (stream len " + stream.Length + "), OPCODEs: " + sb.ToString(), LOG_DETAIL.INSANE);
+            Debug((def.name ?? "null") + " (stream len " + stream.Length + "), OPCODEs: " + SharedBuilder.ToString(), LOG_DETAIL.INSANE);
             return def;
         }
 

--- a/FlashEditor/Definitions/NPCDefinition.cs
+++ b/FlashEditor/Definitions/NPCDefinition.cs
@@ -162,7 +162,7 @@ namespace FlashEditor
                     {
                         int idx = opcode - 30;
                         options[idx] = stream.ReadJagexString();
-                        if (options[idx] == "Hidden")
+                        if (string.Equals(options[idx], "Hidden", StringComparison.Ordinal))
                             options[idx] = null;
                         break;
                     }
@@ -404,7 +404,7 @@ namespace FlashEditor
                     {
                         int idx = opcode - 150;
                         options[idx] = stream.ReadJagexString();
-                        if (options[idx] == "Hidden")
+                        if (string.Equals(options[idx], "Hidden", StringComparison.Ordinal))
                             options[idx] = null;
                         break;
                     }

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -32,7 +32,7 @@ namespace FlashEditor {
         }
 
         public bool IsCacheDirSet() {
-            if(Properties.Settings.Default.cacheDir == "")
+            if(string.Equals(Properties.Settings.Default.cacheDir, string.Empty, StringComparison.Ordinal))
                 return false;
             return true;
         }
@@ -55,7 +55,7 @@ namespace FlashEditor {
         }
 
         private void Editor_Load(object sender, EventArgs e) {
-            if(Properties.Settings.Default.cacheDir != "")
+            if(!string.Equals(Properties.Settings.Default.cacheDir, string.Empty, StringComparison.Ordinal))
                 LoadCache(Properties.Settings.Default.cacheDir);
             NPCListView.AlwaysGroupByColumn = npcIdColumn;
             ItemListView.AlwaysGroupByColumn = ItemID;

--- a/FlashEditor/IO/JagStream.cs
+++ b/FlashEditor/IO/JagStream.cs
@@ -10,6 +10,8 @@ namespace FlashEditor {
         public JagStream(byte[] buffer) : base(buffer) { }
         public JagStream() { }
 
+        private static readonly StringBuilder SharedBuilder = new StringBuilder();
+
         /*
          * The modified set of 'extended ASCII' characters used by the client.
          */
@@ -166,14 +168,14 @@ namespace FlashEditor {
         }
 
         internal string ReadString2() {
-            StringBuilder sb = new StringBuilder();
+            SharedBuilder.Clear();
             int b;
 
             while((b = ReadByte()) != 0)
-                sb.Append((char) b);
+                SharedBuilder.Append((char) b);
 
             WriteLine("'");
-            return sb.ToString();
+            return SharedBuilder.ToString();
         }
 
         /**
@@ -183,21 +185,21 @@ namespace FlashEditor {
          * @return The decoded string.
          */
         public string ReadJagexString() {
-            StringBuilder sb = new StringBuilder();
+            SharedBuilder.Clear();
             int b;
             while((b = ReadByte()) != 0) {
                 //If the byte read is between 127 and 159, it should be remapped
                 if(b >= 127 && b < 160) {
                     char c = CHARACTERS[b - 128];
-                    if(c.Equals('\0')) //if it needs to be remapped, as per the characters array
+                    if(c == '\0') //if it needs to be remapped, as per the characters array
                         c = '\u003F'; //replace with question mark as placeholder to avoid rendering issues
-                    sb.Append(c);
+                    SharedBuilder.Append(c);
                 } else {
-                    sb.Append((char) b);
+                    SharedBuilder.Append((char) b);
                 }
             }
 
-            return sb.ToString();
+            return SharedBuilder.ToString();
         }
 
         internal byte Get(int pos) {
@@ -221,12 +223,12 @@ namespace FlashEditor {
 
         //Seems to work better? idk tbh my brain is fried...
         public string ReadFlashString() {
-            StringBuilder sb = new StringBuilder();
+            SharedBuilder.Clear();
             int b;
             while((b = ReadByte()) != 0) {
                 if(b >= 128 && b < 160) {
                     char c = CHARACTERS[b - 128];
-                    sb.Append(c == (char) 0 ? (char) 63 : c);
+                    SharedBuilder.Append(c == (char) 0 ? (char) 63 : c);
                 } else {
                     //Nobody seems to have this (including client, openrs, etc)
                     //Seems to eliminate issues reading strings not terminated by 0
@@ -236,11 +238,11 @@ namespace FlashEditor {
                         break;
                     }
 
-                    sb.Append((char) b);
+                        SharedBuilder.Append((char) b);
                 }
             }
 
-            return sb.ToString();
+            return SharedBuilder.ToString();
         }
 
         /*


### PR DESCRIPTION
## Summary
- reuse shared `StringBuilder` instances
- switch string checks to `StringComparison.Ordinal`

## Testing
- `dotnet test` *(fails: NETSDK1100 Windows targeting)*

------
https://chatgpt.com/codex/tasks/task_e_684ea78dd6c0832d8bfa0efd59dac331