### PR TITLE
Fix bounds checks and logical operators

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -165,7 +165,7 @@ namespace FlashEditor.cache {
         /// <param name="containerId">The container index</param>
         /// <returns>Container with index <paramref name="containerId"/> from the specified <paramref name="type"/></returns>
         public RSContainer GetContainer(int type, int containerId) {
-            if(containerId < 0 || containerId > store.GetFileCount(type))
+            if(containerId < 0 || containerId >= store.GetFileCount(type))
                 throw new FileNotFoundException("Could not find container type " + type);
 
             //Initialise the container dictionary
@@ -321,7 +321,7 @@ namespace FlashEditor.cache {
         /// <returns></returns>
 
         public RSReferenceTable GetReferenceTable(int type) {
-            if(type < 0 || type > store.GetTypeCount())
+            if(type < 0 || type >= store.GetTypeCount())
                 throw new FileNotFoundException("\tERROR - Reference table " + type + " out of bounds");
 
             if(referenceTables[type] == null) {

--- a/FlashEditor/Cache/RSFileStore.cs
+++ b/FlashEditor/Cache/RSFileStore.cs
@@ -47,9 +47,9 @@ namespace FlashEditor.cache {
         }
 
         /// <summary>
-        /// Returns the total number of non-meta indices
+        /// Returns the highest non-meta index rather than a true count.
         /// </summary>
-        /// <returns>The length of the <param name="indexChannels"> array</returns>
+        /// <returns>The maximum index present in <paramref name="indexChannels"/></returns>
         internal int GetTypeCount() {
             if(indexChannels == null)
                 throw new NullReferenceException("IndexChannels is null");

--- a/FlashEditor/Cache/RSIdentifiers.cs
+++ b/FlashEditor/Cache/RSIdentifiers.cs
@@ -52,7 +52,6 @@ namespace FlashEditor.Cache.CheckSum {
         }
 
         public RSIdentifiers(int[] identifiers) {
-            return;
 
             //Initial identifier sizes
             int length = identifiers.Length;

--- a/FlashEditor/Cache/Region/HeightCalc.cs
+++ b/FlashEditor/Cache/Region/HeightCalc.cs
@@ -49,9 +49,9 @@ namespace FlashEditor.Cache.Region {
 
         static int InterpolateNoise(int x, int y, int frequency) {
             int intX = x / frequency;
-            int fracX = x & frequency - 1;
+            int fracX = x & (frequency - 1);
             int intY = y / frequency;
-            int fracY = y & frequency - 1;
+            int fracY = y & (frequency - 1);
             int v1 = SmoothedNoise1(intX, intY);
             int v2 = SmoothedNoise1(intX + 1, intY);
             int v3 = SmoothedNoise1(intX, intY + 1);

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -380,7 +380,7 @@ namespace FlashEditor {
 
         public int GetEditorType() {
             int editorIndex = EditorTabControl.SelectedIndex;
-            if(editorIndex > 0 & editorIndex < editorTypes.Length)
+            if(editorIndex > 0 && editorIndex < editorTypes.Length)
                 return editorTypes[editorIndex];
             return -1;
         }


### PR DESCRIPTION
## Summary
- fix `GetEditorType` to use `&&`
- correct bounds checks in `GetContainer` and `GetReferenceTable`
- clarify comment on `RSFileStore.GetTypeCount`
- fix bitwise precedence in `HeightCalc.InterpolateNoise`
- remove early return in `RSIdentifiers` constructor

## Testing
- `dotnet test --no-build` *(fails: produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_684ead08d8ac832dbe3bd795b46f6168