### PR TITLE
Add LINQ chain loop style check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,5 @@ The editor loads, displays, and modifies the RuneScape JS5 cache for revision 63
 
 The editor also supports features such as MIDI music playback and the modern index layout (0–36 plus 255). When porting assets to other revisions, keep in mind that opcode mappings and file formats may differ significantly after revision 669.
 
+## Performance Guidelines
+- Avoid using heavy LINQ chains like `Where().Select().ToList()` inside performance-critical loops. Use a single-pass `for` loop to filter and transform in one step.

--- a/FlashEditor.Tests/Style/LinqChainLoopTests.cs
+++ b/FlashEditor.Tests/Style/LinqChainLoopTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace FlashEditor.Tests.Style
+{
+    public class LinqChainLoopTests
+    {
+        [Fact]
+        public void NoLinqWhereSelectToListInLoops()
+        {
+            var root = Path.Combine("..", "..", "FlashEditor");
+            foreach (var file in Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                var lines = File.ReadAllLines(file);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    var line = lines[i];
+                    if (line.Contains(".Where(") && line.Contains(".Select(") && line.Contains(".ToList(") && IsInsideLoop(lines, i))
+                    {
+                        Assert.False(true, $"LINQ chain .Where().Select().ToList() inside loop in {file} at line {i + 1}. Use a single-pass loop instead.");
+                    }
+                }
+            }
+        }
+
+        private static bool IsInsideLoop(string[] lines, int index)
+        {
+            for (int i = index; i >= 0 && index - i < 5; i--)
+            {
+                var trimmed = lines[i].TrimStart();
+                if (trimmed.StartsWith("for(") || trimmed.StartsWith("for (") ||
+                    trimmed.StartsWith("foreach(") || trimmed.StartsWith("foreach (") ||
+                    trimmed.StartsWith("while(") || trimmed.StartsWith("while (") )
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add guidance on avoiding chained LINQ in hot loops
- add test to scan for `.Where().Select().ToList()` inside loops

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop runtime not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb99ee658832d83de1581e63c148f