### PR TITLE
Optimize whirlpool reads

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -141,8 +141,10 @@ namespace FlashEditor.cache {
             entry.SetVersion(1337);
 
             //Calculate and update the whirlpool digest if we need to
-            if(table.usesWhirlpool)
-                entry.SetWhirlpool(Whirlpool.GetHash(hashableStream.ToArray()));
+            if(table.usesWhirlpool) {
+                byte[] digest = Whirlpool.GetHash(hashableStream.ToArray());
+                entry.SetWhirlpool(digest);
+            }
 
             //Add the entry to the reference table
             table.PutEntry(containerId, entry);

--- a/FlashEditor/Cache/RSEntry.cs
+++ b/FlashEditor/Cache/RSEntry.cs
@@ -56,12 +56,12 @@ namespace FlashEditor.cache {
             return whirlpool;
         }
 
-        public virtual void SetWhirlpool(byte[] whirlpool) {
+        public virtual void SetWhirlpool(ReadOnlySpan<byte> whirlpool) {
             if(whirlpool.Length != 64) {
                 Debug("Whirlpool length is not 64 bytes");
                 throw new ArgumentException();
             }
-            Array.Copy(whirlpool, 0, this.whirlpool, 0, whirlpool.Length);
+            whirlpool.CopyTo(this.whirlpool);
         }
 
         public JagStream GetStream() {

--- a/FlashEditor/Cache/RSReferenceTable.cs
+++ b/FlashEditor/Cache/RSReferenceTable.cs
@@ -95,8 +95,8 @@ namespace FlashEditor.cache {
             //If the archive uses whirlpool, set the whirlpool hash
             if(table.usesWhirlpool) {
                 for(int index = 0; index < table.validArchivesCount; index++) {
-                    byte[] whirpool = new byte[64];
-                    stream.Read(whirpool, 0, 64);
+                    Span<byte> whirpool = stackalloc byte[64];
+                    stream.Read(whirpool);
                     table.entries[table.validArchiveIds[index]].SetWhirlpool(whirpool);
                 }
             }


### PR DESCRIPTION
## Summary
- avoid allocating new byte[64] for each whirlpool digest
- use stackalloc spans and ReadOnlySpan SetWhirlpool

## Testing
- `dotnet restore` *(fails: EnableWindowsTargeting)*
- `dotnet build FlashEditor.sln --no-restore` *(fails: project.assets.json not found + EnableWindowsTargeting)*
- `dotnet test -v normal` *(fails: EnableWindowsTargeting)*

------
https://chatgpt.com/codex/tasks/task_e_684eb99c1bbc832d8fb2c30849036119