### PR TITLE
Fix null reference issues

### DIFF
--- a/FlashEditor/Definitions/Models/ModelDefinition.cs
+++ b/FlashEditor/Definitions/Models/ModelDefinition.cs
@@ -1378,9 +1378,11 @@ namespace FlashEditor.Definitions.Model {
                         maxDepth = functionZ;
                 }
                 if(this.anInt1234 > 0 && (i_127_ & 8) != 0) {
-                    this.aByteArray1241[tri] = (byte) var3.ReadUnsignedByte();
-                    this.aByteArray1266[tri] = (byte) var3.ReadUnsignedByte();
-                    this.aByteArray1243[tri] = (byte) var3.ReadUnsignedByte();
+                    if(var3 != null) {
+                        this.aByteArray1241[tri] = (byte) var3.ReadUnsignedByte();
+                        this.aByteArray1266[tri] = (byte) var3.ReadUnsignedByte();
+                        this.aByteArray1243[tri] = (byte) var3.ReadUnsignedByte();
+                    }
                 }
             }
             maxDepth++;

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -419,7 +419,9 @@ namespace FlashEditor {
             Debug(@"|______\__,_|_|\__| |_____|\__\___|_| |_| |_|");
             Debug("Edit Item");
 
-            Debug("itemdef name: " + currentItem.name);
+            Debug("itemdef name: " + (currentItem != null ? currentItem.name : "<none>"));
+            if(currentItem == null)
+                currentItem = ((ItemDefinition) e.RowObject).Clone();
 
             //Get the object represented by the ListView
             ItemDefinition newDefinition = (ItemDefinition) e.RowObject;

--- a/FlashEditor/Utils/Debugging.cs
+++ b/FlashEditor/Utils/Debugging.cs
@@ -107,8 +107,19 @@ namespace FlashEditor.utils {
         }
 
         public static void PrintDifferences(object a, object b) {
+            if(a == null || b == null) {
+                if(a != b)
+                    Debug("\tObjects differ (null vs non-null)");
+                return;
+            }
+
             Dictionary<string, object> propsA = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(a));
             Dictionary<string, object> propsB = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(b));
+
+            if(propsA == null || propsB == null) {
+                Debug("Unable to evaluate differences - serialization failed");
+                return;
+            }
 
             Debug("Evaluating changes...");
 


### PR DESCRIPTION
## Summary
- avoid dereferencing `currentItem` before it's initialized
- check for missing data when comparing objects
- guard against missing JagStream in `CalculateMaxDepth`

## Testing
- `dotnet build FlashEditor.sln /p:EnableWindowsTargeting=true --no-restore` *(fails: RSEntry missing methods)*

------
https://chatgpt.com/codex/tasks/task_e_684eb967e62c832d89c3d53b2a2aa5c5