### PR TITLE
Improve string handling in loops

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -4,6 +4,7 @@ using ICSharpCode.SharpZipLib.Checksum;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using static FlashEditor.utils.DebugUtil;
 
 namespace FlashEditor.cache {
@@ -55,8 +56,13 @@ namespace FlashEditor.cache {
         /// <param name="type">The index type</param>
         /// <returns>Whether or not the index was successfully written</returns>
         internal void SaveIndexes() {
-            foreach(KeyValuePair<int, RSIndex> index in GetStore().indexChannels)
-                SaveIndex(index.Value, "idx" + index.Key);
+            var sb = new StringBuilder();
+            foreach(KeyValuePair<int, RSIndex> index in GetStore().indexChannels) {
+                sb.Clear();
+                sb.Append("idx");
+                sb.Append(index.Key);
+                SaveIndex(index.Value, sb.ToString());
+            }
         }
 
         internal void SaveIndex(RSIndex index, string directory) {

--- a/FlashEditor/Cache/RSFileStore.cs
+++ b/FlashEditor/Cache/RSFileStore.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 namespace FlashEditor.cache {
     public class RSFileStore {
@@ -20,9 +21,14 @@ namespace FlashEditor.cache {
             dataChannel = LoadIndex(cacheDir + "dat2");
 
             //And load in the data from the meta indexes, including reference tables
-            for(int k = 0; k <= RSConstants.META_INDEX; k++)
-                if(File.Exists(cacheDir + "idx" + k))
-                    indexChannels.Add(k, LoadIndex(cacheDir + "idx" + k));
+            var sb = new StringBuilder();
+            for(int k = 0; k <= RSConstants.META_INDEX; k++) {
+                sb.Clear();
+                sb.Append(cacheDir).Append("idx").Append(k);
+                string path = sb.ToString();
+                if(File.Exists(path))
+                    indexChannels.Add(k, LoadIndex(path));
+            }
         }
 
         /// <summary>

--- a/FlashEditor/Cache/RSReferenceTable.cs
+++ b/FlashEditor/Cache/RSReferenceTable.cs
@@ -2,6 +2,7 @@
 using static FlashEditor.utils.DebugUtil;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using FlashEditor.utils;
 
 namespace FlashEditor.cache {
@@ -160,6 +161,8 @@ namespace FlashEditor.cache {
 
             JagStream stream = new JagStream();
 
+            var sb = new StringBuilder();
+
             Debug("\tOUT Table version: " + version + " | Format: " + format + " | Flags: " + (flags == 1 ? "Y" : "N") + " | Archives: " + validArchivesCount + " | Whirl: " + (usesWhirlpool ? "Y" : "N"), LOG_DETAIL.ADVANCED);
 
             stream.WriteByte((byte) format);
@@ -182,7 +185,9 @@ namespace FlashEditor.cache {
                 Debug("Writing identifiers", LOG_DETAIL.INSANE);
                 foreach(KeyValuePair<int, RSEntry> kvp in entries) {
                     int ident = kvp.Value.GetIdentifier();
-                    Debug("\t-" + ident);
+                    sb.Clear();
+                    sb.Append('\t').Append('-').Append(ident);
+                    Debug(sb.ToString());
                     stream.WriteInteger(ident);
                 }
             }
@@ -190,7 +195,9 @@ namespace FlashEditor.cache {
             Debug("Writing CRCs", LOG_DETAIL.INSANE);
             foreach(KeyValuePair<int, RSEntry> kvp in entries) {
                 int crc = kvp.Value.GetCrc();
-                Debug("\t|" + crc);
+                sb.Clear();
+                sb.Append('\t').Append('|').Append(crc);
+                Debug(sb.ToString());
                 stream.WriteInteger(kvp.Value.GetCrc());
             }
 
@@ -198,7 +205,9 @@ namespace FlashEditor.cache {
                 foreach(KeyValuePair<int, RSEntry> kvp in entries) {
                     int hash = kvp.Value.CalculateHash();
                     stream.WriteInteger(hash);
-                    Debug("\t|" + hash);
+                    sb.Clear();
+                    sb.Append('\t').Append('|').Append(hash);
+                    Debug(sb.ToString());
                 }
 
             if(usesWhirlpool) {
@@ -218,7 +227,12 @@ namespace FlashEditor.cache {
                     int uncomp = kvp.Value.uncompressed;
                     stream.WriteInteger(kvp.Value.compressed);
                     stream.WriteInteger(kvp.Value.uncompressed);
-                    Debug("\t|comp: " + comp + ", uncomp: " + uncomp);
+                    sb.Clear();
+                    sb.Append("\t|comp: ");
+                    sb.Append(comp);
+                    sb.Append(", uncomp: ");
+                    sb.Append(uncomp);
+                    Debug(sb.ToString());
                 }
             }
 
@@ -226,14 +240,18 @@ namespace FlashEditor.cache {
             foreach(KeyValuePair<int, RSEntry> kvp in entries) {
                 int version = kvp.Value.GetVersion();
                 stream.WriteInteger(kvp.Value.GetVersion());
-                Debug("\t|" + version);
+                sb.Clear();
+                sb.Append('\t').Append('|').Append(version);
+                Debug(sb.ToString());
             }
 
             Debug("Writing number of non-null child entries", LOG_DETAIL.INSANE);
             foreach(KeyValuePair<int, RSEntry> kvp in entries) {
                 int nnce = kvp.Value.GetChildEntries().Count;
                 stream.WriteShort(nnce);
-                Debug("\t|" + nnce);
+                sb.Clear();
+                sb.Append('\t').Append('|').Append(nnce);
+                Debug(sb.ToString());
             }
 
             Debug("Writing child IDs", LOG_DETAIL.INSANE);
@@ -253,7 +271,9 @@ namespace FlashEditor.cache {
                     foreach(KeyValuePair<int, RSChildEntry> child in kvp.Value.GetChildEntries()) {
                         int childIdent = child.Value.GetIdentifier();
                         stream.WriteInteger(childIdent);
-                        Debug("\t|" + childIdent);
+                        sb.Clear();
+                        sb.Append('\t').Append('|').Append(childIdent);
+                        Debug(sb.ToString());
                     }
             }
 

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Windows.Forms;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text;
 using BrightIdeasSoftware;
 using FlashEditor.Tests;
 
@@ -228,7 +229,7 @@ namespace FlashEditor {
 
                                     //Only update the progress bar for each 1% completed
                                     if(done % percentile == 0 || done == total)
-                                        bgw.ReportProgress((done + 1) * 100 / total, "Loaded " + done + "/" + total + " (" + (done + 1) * 100 / total + "%)");
+                                        bgw.ReportProgress((done + 1) * 100 / total, BuildProgressMessage(done, total));
                                 }
                             }
                         }
@@ -283,7 +284,7 @@ namespace FlashEditor {
 
                                 //Only update the progress bar for each 1% completed
                                 if(done % percentile == 0 || done == total)
-                                    bgw.ReportProgress((done + 1) * 100 / total, "Loaded " + done + "/" + total + " (" + (done + 1) * 100 / total + "%)");
+                                    bgw.ReportProgress((done + 1) * 100 / total, BuildProgressMessage(done, total));
                             } catch(Exception ex) {
                                 Debug(ex.Message);
                             }
@@ -352,7 +353,7 @@ namespace FlashEditor {
 
                                     //Only update the progress bar for each 1% completed
                                     if(done % percentile == 0 || done == total)
-                                        bgw.ReportProgress((done + 1) * 100 / total, "Loaded " + done + "/" + total + " (" + (done + 1) * 100 / total + "%)");
+                                        bgw.ReportProgress((done + 1) * 100 / total, BuildProgressMessage(done, total));
                                 }
                             }
                         }
@@ -514,8 +515,13 @@ namespace FlashEditor {
             Debug(@"Analysing");
 
             int diff = AnalyseCache("dat2");
-            foreach(KeyValuePair<int, RSIndex> index in cache.GetStore().indexChannels)
-                diff += AnalyseCache("idx" + index.Key);
+            var sb = new StringBuilder();
+            foreach(KeyValuePair<int, RSIndex> index in cache.GetStore().indexChannels) {
+                sb.Clear();
+                sb.Append("idx");
+                sb.Append(index.Key);
+                diff += AnalyseCache(sb.ToString());
+            }
 
             Debug("Analysis complete, " + (diff > 0 ? diff + " differences found" : "no differences found"));
         }
@@ -577,6 +583,19 @@ namespace FlashEditor {
 
         private void numericUpDown1_ValueChanged_1(object sender, EventArgs e) {
             SpriteListView.RowHeight = (int) numericUpDown1.Value;
+        }
+
+        private static string BuildProgressMessage(int done, int total) {
+            var sb = new StringBuilder();
+            sb.Append("Loaded ");
+            sb.Append(done);
+            sb.Append('/');
+            sb.Append(total);
+            sb.Append(" (");
+            sb.Append((done + 1) * 100 / total);
+            sb.Append('%');
+            sb.Append(')');
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor progress loops to build messages via `StringBuilder`
- avoid repeated allocations for index filenames when saving
- construct reference table debug output with a shared builder
- use `StringBuilder` for cache file detection

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App 9.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb99948e4832d9c17478a61977a00