### PR TITLE
Enable editing for NPC/object columns

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -19,6 +19,7 @@ namespace FlashEditor.cache {
         //Better to make generic type Definition and store each of them under their respective indexes but that's for later anyway
         public SortedDictionary<int, ItemDefinition> items = new SortedDictionary<int, ItemDefinition>();
         public SortedDictionary<int, ObjectDefinition> objects = new SortedDictionary<int, ObjectDefinition>();
+        public SortedDictionary<int, NPCDefinition> npcs = new SortedDictionary<int, NPCDefinition>();
 
         /// <summary>
         /// Create a new Cache instance, and automatically memoizes the archives and their reference tables

--- a/FlashEditor/Definitions/NPCDefinition.cs
+++ b/FlashEditor/Definitions/NPCDefinition.cs
@@ -1,8 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace FlashEditor
 {
-    internal class NPCDefinition : IDefinition
+    internal class NPCDefinition : ICloneable, IDefinition
     {
         sbyte primaryShadowModifier = -33;
         byte respawnDirection = 7;
@@ -741,5 +742,11 @@ namespace FlashEditor
         {
             this.id = id;
         }
+
+        /// <summary>
+        /// Creates a shallow copy of this <see cref="NPCDefinition"/>.
+        /// </summary>
+        public NPCDefinition Clone() => (NPCDefinition)MemberwiseClone();
+        object ICloneable.Clone() => Clone();
     }
 }

--- a/FlashEditor/Editor.Designer.cs
+++ b/FlashEditor/Editor.Designer.cs
@@ -935,6 +935,7 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.NPCListView.BackColor = System.Drawing.Color.White;
+            this.NPCListView.CellEditActivation = BrightIdeasSoftware.ObjectListView.CellEditActivateMode.DoubleClick;
             this.NPCListView.CellEditUseWholeCell = false;
             this.NPCListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.npcIdColumn,
@@ -960,11 +961,14 @@
             this.NPCListView.UseCompatibleStateImageBehavior = false;
             this.NPCListView.View = System.Windows.Forms.View.Details;
             this.NPCListView.VirtualMode = true;
+            this.NPCListView.CellEditFinished += new BrightIdeasSoftware.CellEditEventHandler(this.NPCListView_CellEditFinished);
+            this.NPCListView.CellEditStarting += new BrightIdeasSoftware.CellEditEventHandler(this.NPCListView_CellEditStarting);
             // 
             // npcIdColumn
             // 
             this.npcIdColumn.AspectName = "id";
             this.npcIdColumn.Groupable = false;
+            this.npcIdColumn.IsEditable = false;
             this.npcIdColumn.Searchable = false;
             this.npcIdColumn.Text = "ID";
             this.npcIdColumn.Width = 78;
@@ -1089,6 +1093,7 @@
             | System.Windows.Forms.AnchorStyles.Left)
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ObjectListView.BackColor = System.Drawing.Color.White;
+            this.ObjectListView.CellEditActivation = BrightIdeasSoftware.ObjectListView.CellEditActivateMode.DoubleClick;
             this.ObjectListView.CellEditUseWholeCell = false;
             this.ObjectListView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.objectIdColumn,
@@ -1119,6 +1124,7 @@
             //
             this.objectIdColumn.AspectName = "id";
             this.objectIdColumn.Groupable = false;
+            this.objectIdColumn.IsEditable = false;
             this.objectIdColumn.Searchable = false;
             this.objectIdColumn.Text = "ID";
             this.objectIdColumn.Width = 78;

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -382,6 +382,7 @@ namespace FlashEditor
                                 {
                                     NPCDefinition npc = cache.GetNPCDefinition(archiveId, file);
                                     npc.SetId(archiveId * 128 + file); //Set the NPC ID
+                                    cache.npcs[npc.id] = npc;
                                     npcs.Add(npc);
                                 }
                                 catch (Exception ex)
@@ -554,6 +555,20 @@ namespace FlashEditor
             PrintDifferences(newDef, currentObject);
         }
 
+        private void NPCListView_CellEditFinished(object sender, CellEditEventArgs e)
+        {
+            NPCDefinition newDef = (NPCDefinition)e.RowObject;
+            cache.npcs[newDef.id] = newDef;
+
+            int archiveId = newDef.id / 128;
+            int entryId = newDef.id % 128;
+
+            JagStream data = newDef.Encode();
+            cache.WriteEntry(RSConstants.NPC_DEFINITIONS_INDEX, archiveId, entryId, data);
+
+            PrintDifferences(newDef, currentNpc);
+        }
+
         private void ExportItemDatBtn_Click(object sender, EventArgs e)
         {
             ItemLoadingLabel.Text = "Status: Dumping " + ItemListView.SelectedObjects.Count + " Items...";
@@ -665,6 +680,8 @@ namespace FlashEditor
 
         internal ItemDefinition currentItem;
 
+        internal NPCDefinition currentNpc;
+
         internal ObjectDefinition currentObject;
 
         private void ItemListView_CellEditStarting(object sender, CellEditEventArgs e)
@@ -678,6 +695,12 @@ namespace FlashEditor
         {
             currentObject = (ObjectDefinition)ObjectListView.SelectedObject;
             currentObject = currentObject.Clone();
+        }
+
+        private void NPCListView_CellEditStarting(object sender, CellEditEventArgs e)
+        {
+            currentNpc = (NPCDefinition)NPCListView.SelectedObject;
+            currentNpc = currentNpc.Clone();
         }
 
         private void button5_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- make `NPCDefinition` clonable for change tracking
- track NPC definitions in `RSCache`
- allow editing NPC/object fields via ObjectListView

## Testing
- `dotnet build`
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App 9.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68510e56662c832d93a79eeecfff108d