### PR TITLE
Clarify JS5 container header

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,14 @@ The editor loads, displays, and modifies the RuneScape JS5 cache for revision 63
 
 ### Container Wrapper
 - Byte `compressionType` (`0`=none, `1`=BZip2, `2`=GZip)
-- `uncompressedSize` (4 bytes)
+- `compressedSize` (4 bytes)
+- `uncompressedSize` (4 bytes when compressed)
 - Payload (optionally XTEA-encrypted)
 - Optional 3-byte `cumulativeLengths[]` table when the container has multiple files
+
+Revision 639 (and later) expects the header layout above. Some earlier
+revisions swapped the two length fields, so both encode and decode must
+use this ordering to remain compatible with the in-game client.
 
 ### XTEA Layer
 - Applied after compression and before sectorisation

--- a/FlashEditor/Cache/RSContainer.cs
+++ b/FlashEditor/Cache/RSContainer.cs
@@ -42,12 +42,15 @@ namespace FlashEditor.cache {
         ///     Encodes this container to the on‑disk binary representation.
         /// </summary>
         /// <remarks>
-        ///     The header layout matches the client contract: one byte
-        ///     <c>compressionType</c> followed by the 4&nbsp;byte
-        ///     <c>compressedLength</c> and, when compressed, another 4&nbsp;byte
-        ///     <c>uncompressedLength</c>.  The payload may be XTEA encrypted
-        ///     when <paramref name="xteaKey"/> is supplied.  Multi‑file
-        ///     archives must already contain the cumulative length table.
+        ///     Revision 639 uses the modern JS5 container header format:
+        ///     <c>compressionType</c> (1&nbsp;byte) followed by
+        ///     <c>compressedLength</c> and then, when compression is used,
+        ///     <c>uncompressedLength</c>. Earlier revisions swapped the two
+        ///     length fields; maintaining this order ensures compatibility with
+        ///     the 639 client.
+        ///     The payload may be XTEA encrypted when
+        ///     <paramref name="xteaKey"/> is supplied. Multi‑file archives must
+        ///     already contain the cumulative length table.
         /// </remarks>
         /// <param name="xteaKey">Optional 4&nbsp;integer XTEA key. When
         /// <c>null</c> no encryption is performed.</param>
@@ -102,11 +105,20 @@ namespace FlashEditor.cache {
         }
 
         /// <summary>
-        /// Constructs a new <see cref="RSContainer"/> from the stream data
+        ///     Constructs a new <see cref="RSContainer"/> from the stream data.
         /// </summary>
+        /// <remarks>
+        ///     The method expects the header ordering used by revision 639:
+        ///     <c>compressionType</c>, <c>compressedLength</c> and, if
+        ///     compressed, <c>uncompressedLength</c>. Earlier revisions may
+        ///     store the lengths in reverse.
+        /// </remarks>
         /// <param name="stream">The raw container data.</param>
         /// <param name="xteaKey">Optional XTEA key used to decrypt the payload.</param>
-        /// <returns>The new container, or <c>null</c> if <paramref name="stream"/> is null.</returns>
+        /// <returns>
+        ///     The new container, or <c>null</c> if <paramref name="stream"/>
+        ///     is <c>null</c>.
+        /// </returns>
         public static RSContainer Decode(JagStream stream, int[] xteaKey = null) {
             if(stream == null)
                 return null;


### PR DESCRIPTION
## Summary
- fix container wrapper doc to show compressed and uncompressed sizes
- document the header order in RSContainer.Encode and Decode

## Testing
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj` *(fails: missing `Microsoft.WindowsDesktop.App` runtime)*

------
https://chatgpt.com/codex/tasks/task_e_685410a00714832d93abd6947570ed6b