### PR TITLE
Add texture definition loader with test

### DIFF
--- a/FlashEditor.Tests/Definitions/TextureDefinitionTests.cs
+++ b/FlashEditor.Tests/Definitions/TextureDefinitionTests.cs
@@ -1,0 +1,50 @@
+using FlashEditor;
+using System.Collections.Generic;
+using FlashEditor.Definitions.Sprites;
+using FlashEditor.cache;
+using Xunit;
+
+namespace FlashEditor.Tests.Definitions
+{
+    public class TextureDefinitionTests
+    {
+        private static byte[] BuildTexture(int count, ushort[] fileIds, int[] colors)
+        {
+            var s = new JagStream();
+            s.WriteShort(0);
+            s.WriteByte(0);
+            s.WriteByte((byte)count);
+            foreach (var id in fileIds)
+                s.WriteShort((short)id);
+            if (count > 1)
+            {
+                for (int i = 0; i < count - 1; i++) s.WriteByte(0);
+                for (int i = 0; i < count - 1; i++) s.WriteByte(0);
+            }
+            foreach (var c in colors)
+                s.WriteInteger(c);
+            s.WriteByte(0);
+            s.WriteByte(0);
+            s.Flip();
+            return s.ToArray();
+        }
+
+        [Fact]
+        public void Loader_Decodes_All_Entries()
+        {
+            var loader = new TextureLoader();
+
+            var archive = new RSArchive();
+            archive.PutEntry(0, new JagStream(BuildTexture(1, new ushort[] { 10 }, new int[] { 0x11223344 })));
+            archive.PutEntry(1, new JagStream(BuildTexture(2, new ushort[] { 20, 21 }, new int[] { 1, 2 })));
+
+            var defs = new List<TextureDefinition>();
+            foreach (var kvp in archive.entries)
+                defs.Add(loader.Load(kvp.Key, kvp.Value.ToArray()));
+
+            Assert.Equal(2, defs.Count);
+            Assert.Equal(1, defs[0].fileIds.Length);
+            Assert.Equal(2, defs[1].fileIds.Length);
+        }
+    }
+}

--- a/FlashEditor/Definitions/Sprites/TextureDefinition.cs
+++ b/FlashEditor/Definitions/Sprites/TextureDefinition.cs
@@ -1,0 +1,89 @@
+using FlashEditor;
+using System;
+using System.Collections.Generic;
+
+namespace FlashEditor.Definitions.Sprites
+{
+    /// <summary>
+    /// Representation of a texture definition from the RuneScape cache.
+    /// </summary>
+    public class TextureDefinition : IDefinition
+    {
+        public int field1777;
+        public bool field1778;
+        public int id;
+        public int[] fileIds;
+        public int[] field1780;
+        public int[] field1781;
+        public int[] field1786;
+        public int animationSpeed;
+        public int animationDirection;
+
+        public int[] pixels;
+        public int width;
+
+        public void Decode(JagStream s, int[] xteaKey = null)
+        {
+            field1777 = s.ReadUnsignedShort();
+            field1778 = s.ReadByte() != 0;
+
+            int count = s.ReadUnsignedByte();
+            fileIds = new int[count];
+            for (int i = 0; i < count; i++)
+                fileIds[i] = s.ReadUnsignedShort();
+
+            if (count > 1)
+            {
+                field1780 = new int[count - 1];
+                for (int i = 0; i < count - 1; i++)
+                    field1780[i] = s.ReadUnsignedByte();
+
+                field1781 = new int[count - 1];
+                for (int i = 0; i < count - 1; i++)
+                    field1781[i] = s.ReadUnsignedByte();
+            }
+
+            field1786 = new int[count];
+            for (int i = 0; i < count; i++)
+                field1786[i] = s.ReadInt();
+
+            animationDirection = s.ReadUnsignedByte();
+            animationSpeed = s.ReadUnsignedByte();
+        }
+
+        public static TextureDefinition DecodeFromStream(int id, JagStream stream)
+        {
+            var def = new TextureDefinition { id = id };
+            def.Decode(stream);
+            return def;
+        }
+
+        public JagStream Encode()
+        {
+            var s = new JagStream();
+            s.WriteShort(field1777);
+            s.WriteByte((byte)(field1778 ? 1 : 0));
+
+            int count = fileIds?.Length ?? 0;
+            s.WriteByte((byte)count);
+            for (int i = 0; i < count; i++)
+                s.WriteShort((short)fileIds[i]);
+
+            if (count > 1)
+            {
+                for (int i = 0; i < count - 1; i++)
+                    s.WriteByte((byte)field1780[i]);
+                for (int i = 0; i < count - 1; i++)
+                    s.WriteByte((byte)field1781[i]);
+            }
+
+            for (int i = 0; i < count; i++)
+                s.WriteInteger(field1786[i]);
+
+            s.WriteByte((byte)animationDirection);
+            s.WriteByte((byte)animationSpeed);
+            s.Flip();
+            return s;
+        }
+    }
+}

--- a/FlashEditor/Definitions/Sprites/TextureLoader.cs
+++ b/FlashEditor/Definitions/Sprites/TextureLoader.cs
@@ -1,0 +1,14 @@
+using FlashEditor;
+namespace FlashEditor.Definitions.Sprites
+{
+    /// <summary>
+    /// Decodes raw texture definition data.
+    /// </summary>
+    public class TextureLoader
+    {
+        public TextureDefinition Load(int id, byte[] data)
+        {
+            return TextureDefinition.DecodeFromStream(id, new JagStream(data));
+        }
+    }
+}

--- a/FlashEditor/Definitions/Sprites/TextureManager.cs
+++ b/FlashEditor/Definitions/Sprites/TextureManager.cs
@@ -1,0 +1,36 @@
+using FlashEditor;
+using System.Collections.Generic;
+using FlashEditor.cache;
+
+namespace FlashEditor.Definitions.Sprites
+{
+    /// <summary>
+    /// Loads all texture definitions from the cache.
+    /// </summary>
+    public class TextureManager
+    {
+        private readonly RSCache cache;
+        public readonly List<TextureDefinition> Textures = new List<TextureDefinition>();
+
+        public TextureManager(RSCache cache)
+        {
+            this.cache = cache;
+        }
+
+        public void Load()
+        {
+            RSReferenceTable table = cache.GetReferenceTable(RSConstants.TEXTURES);
+            RSEntry entry = table.GetEntry(0);
+            if (entry == null)
+                return;
+
+            var loader = new TextureLoader();
+            foreach (int fileId in entry.GetValidFileIds())
+            {
+                JagStream data = cache.ReadEntry(RSConstants.TEXTURES, 0, fileId);
+                var def = loader.Load(fileId, data.ToArray());
+                Textures.Add(def);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TextureDefinition` implementing `IDefinition`
- add `TextureLoader` and `TextureManager`
- unit test verifying texture loader decodes all entries

## Testing
- `dotnet test --no-build` *(fails: missing .NET framework)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebb9a45c832d8dffdfc24c6f3b3d