### PR TITLE
Add textured model viewer support

### DIFF
--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -19,11 +19,12 @@ namespace FlashEditor {
     public partial class Editor : Form {
         internal RSCache cache;
         private readonly ModelRenderer _modelRenderer = new ModelRenderer();
+        private GLTextureCache? _textureCache;
         private readonly Dictionary<int, System.Threading.Tasks.Task<ModelDefinition>> _modelTasks = new();
 
         private readonly Timer _fpsTimer = new();
         private int _program;
-        private int _uModel, _uView, _uProj;
+        private int _uModel, _uView, _uProj, _uTexture;
         private Matrix4 _model = Matrix4.Identity;
         private Matrix4 _view;
         private Matrix4 _proj;
@@ -72,8 +73,8 @@ namespace FlashEditor {
         private void Gl_Load(object sender, EventArgs e) {
             glControl.MakeCurrent();
 
-            int vert = CompileShader(ShaderType.VertexShader, LoadShader("basic.vert"));
-            int frag = CompileShader(ShaderType.FragmentShader, LoadShader("basic.frag"));
+            int vert = CompileShader(ShaderType.VertexShader, LoadShader("texture.vert"));
+            int frag = CompileShader(ShaderType.FragmentShader, LoadShader("texture.frag"));
 
             _program = GL.CreateProgram();
             GL.AttachShader(_program, vert);
@@ -88,9 +89,10 @@ namespace FlashEditor {
             _uModel = GL.GetUniformLocation(_program, "uModel");
             _uView = GL.GetUniformLocation(_program, "uView");
             _uProj = GL.GetUniformLocation(_program, "uProj");
-            float[] v = { -0.5f, -0.5f, 0f, 0.5f, -0.5f, 0f, 0f, 0.5f, 0f };
-            ushort[] i = { 0, 1, 2 };
-            _modelRenderer.Load(v, i);
+            _uTexture = GL.GetUniformLocation(_program, "uTexture");
+            GL.UseProgram(_program);
+            GL.Uniform1(_uTexture, 0);
+            GL.UseProgram(0);
 
             GL.ClearColor(0.1f, 0.15f, 0.20f, 1.0f);
             GL.Enable(EnableCap.DepthTest);
@@ -234,6 +236,7 @@ namespace FlashEditor {
                 //Load the cache and the reference tables
                 RSFileStore store = new RSFileStore(directory);
                 cache = new RSCache(store);
+                _textureCache = new GLTextureCache(cache);
                 sw.Stop();
 
                 Debug("Loaded cache in " + sw.ElapsedMilliseconds + "ms");
@@ -841,7 +844,8 @@ namespace FlashEditor {
                 // Check cache
                 if (cache.models.TryGetValue(id, out var def)) {
                     Debug($"Cache hit for model {id} – rendering immediately.", LOG_DETAIL.ADVANCED);
-                    _modelRenderer.Load(def);
+                    if (_textureCache != null)
+                        _modelRenderer.Load(def, _textureCache);
                     glControl.Invalidate();
                     return;
                 }
@@ -876,7 +880,8 @@ namespace FlashEditor {
                         _modelTasks.Remove(id);
 
                         Debug($"[UI] Rendering loaded model {id}", LOG_DETAIL.ADVANCED);
-                        _modelRenderer.Load(loaded);
+                        if (_textureCache != null)
+                            _modelRenderer.Load(loaded, _textureCache);
                         glControl.Invalidate();
                     }
                     else if (t.IsFaulted) {
@@ -940,6 +945,7 @@ namespace FlashEditor {
         protected override void OnFormClosed(FormClosedEventArgs e) {
             _fpsTimer.Stop();
             _modelRenderer.Dispose();
+            _textureCache?.Dispose();
             if (_program != 0)
                 GL.DeleteProgram(_program);
             base.OnFormClosed(e);

--- a/FlashEditor/FlashEditor.csproj
+++ b/FlashEditor/FlashEditor.csproj
@@ -104,5 +104,11 @@
     <Content Include="Shaders\basic.frag">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Shaders\texture.vert">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Shaders\texture.frag">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/FlashEditor/GLTextureCache.cs
+++ b/FlashEditor/GLTextureCache.cs
@@ -1,0 +1,78 @@
+using FlashEditor.cache;
+using FlashEditor.Definitions.Sprites;
+using FlashEditor.cache.util;
+using FlashEditor.cache.sprites;
+using OpenTK.Graphics.OpenGL;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace FlashEditor
+{
+    /// <summary>
+    /// Creates OpenGL texture objects from cache texture definitions and memoises them.
+    /// </summary>
+    public sealed class GLTextureCache
+    {
+        private readonly RSCache _cache;
+        private readonly Dictionary<int, int> _textures = new();
+        private readonly TextureManager _manager;
+
+        /// <summary>
+        /// Initializes a new instance for the given cache and loads all texture definitions.
+        /// </summary>
+        public GLTextureCache(RSCache cache)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _manager = new TextureManager(cache);
+            _manager.Load();
+        }
+
+        /// <summary>
+        /// Gets the OpenGL texture handle for the given texture id, loading it on demand.
+        /// </summary>
+        /// <param name="textureId">Texture definition id.</param>
+        /// <returns>OpenGL texture handle or 0 if not found.</returns>
+        public int GetTexture(int textureId)
+        {
+            if (_textures.TryGetValue(textureId, out int handle))
+                return handle;
+
+            TextureDefinition def = _manager.Textures.Find(t => t.id == textureId);
+            if (def == null || def.fileIds == null || def.fileIds.Length == 0)
+                return 0;
+
+            SpriteDefinition sprite = _cache.GetSprite(def.fileIds[0]);
+            Bitmap bmp = sprite.GetFrame(0).GetSprite();
+            handle = CreateGLTexture(bmp);
+            _textures[textureId] = handle;
+            return handle;
+        }
+
+        private static int CreateGLTexture(Bitmap bmp)
+        {
+            int tex = GL.GenTexture();
+            GL.BindTexture(TextureTarget.Texture2D, tex);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Linear);
+            GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMagFilter.Linear);
+
+            BitmapData data = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba, bmp.Width, bmp.Height, 0, OpenTK.Graphics.OpenGL.PixelFormat.Bgra, PixelType.UnsignedByte, data.Scan0);
+            bmp.UnlockBits(data);
+            GL.GenerateMipmap(GenerateMipmapTarget.Texture2D);
+            GL.BindTexture(TextureTarget.Texture2D, 0);
+            return tex;
+        }
+
+        /// <summary>
+        /// Deletes all OpenGL textures managed by this instance.
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var kvp in _textures)
+                GL.DeleteTexture(kvp.Value);
+            _textures.Clear();
+        }
+    }
+}

--- a/FlashEditor/ModelRenderer.cs
+++ b/FlashEditor/ModelRenderer.cs
@@ -1,73 +1,122 @@
 using FlashEditor.Definitions;
 using OpenTK.Graphics.OpenGL;
 using FlashEditor.Utils;
+using FlashEditor;
+using System.Collections.Generic;
 
-internal sealed class ModelRenderer {
-    private int _vao, _vbo, _ebo, _indexCount;
+internal sealed class ModelRenderer
+{
+    private readonly List<Batch> _batches = new();
 
-    public void Load(ModelDefinition def) {
-        DebugUtil.Debug($"[Load] Start loading ModelDefinition {def.ModelID}", DebugUtil.LOG_DETAIL.ADVANCED);
-
-        float[] verts = new float[def.VertexCount * 3];
-        for (int i = 0; i < def.VertexCount; i++) {
-            verts[i * 3 + 0] = def.VertX[i] / 128f;
-            verts[i * 3 + 1] = def.VertY[i] / 128f;
-            verts[i * 3 + 2] = -def.VertZ[i] / 128f;
-        }
-
-        ushort[] idx = new ushort[def.TriangleCount * 3];
-        for (int i = 0; i < def.TriangleCount; i++) {
-            idx[i * 3 + 0] = (ushort)def.faceIndices1[i];
-            idx[i * 3 + 1] = (ushort)def.faceIndices2[i];
-            idx[i * 3 + 2] = (ushort)def.faceIndices3[i];
-        }
-
-        Load(verts, idx);
-
-        DebugUtil.Debug($"Loaded ModelDefinition {def.ModelID} into OpenGL (VAO={_vao}, indices={_indexCount})", DebugUtil.LOG_DETAIL.ADVANCED);
+    private class Batch
+    {
+        public int VAO;
+        public int VBO;
+        public int EBO;
+        public int IndexCount;
+        public int Texture;
     }
 
-    public void Load(float[] vertices, ushort[] indices) {
-        if (_vao != 0) {
-            GL.DeleteBuffer(_vbo);
-            GL.DeleteBuffer(_ebo);
-            GL.DeleteVertexArray(_vao);
-        }
-
-        _indexCount = indices.Length;
-
-        _vao = GL.GenVertexArray();
-        _vbo = GL.GenBuffer();
-        _ebo = GL.GenBuffer();
-
-        GL.BindVertexArray(_vao);
-
-        GL.BindBuffer(BufferTarget.ArrayBuffer, _vbo);
-        GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * sizeof(float), vertices, BufferUsageHint.StaticDraw);
-        GL.EnableVertexAttribArray(0);
-        GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 3 * sizeof(float), 0);
-
-        GL.BindBuffer(BufferTarget.ElementArrayBuffer, _ebo);
-        GL.BufferData(BufferTarget.ElementArrayBuffer, indices.Length * sizeof(ushort), indices, BufferUsageHint.StaticDraw);
-
-        GL.BindVertexArray(0);
-    }
-
-    public void Draw() {
-        if (_vao == 0)
+    public void Load(ModelDefinition def, GLTextureCache textures)
+    {
+        Dispose();
+        if (def.FaceTextureUCoordinates == null || def.FaceTextureVCoordinates == null)
             return;
 
-        GL.BindVertexArray(_vao);
-        GL.DrawElements(PrimitiveType.Triangles, _indexCount, DrawElementsType.UnsignedShort, 0);
-        GL.BindVertexArray(0);
+        var groups = new Dictionary<int, List<float>>();
+        var indices = new Dictionary<int, List<ushort>>();
+        int vertIndex = 0;
+
+        for (int i = 0; i < def.TriangleCount; i++)
+        {
+            int texId = def.FaceTextures == null ? -1 : def.FaceTextures[i];
+            if (!groups.TryGetValue(texId, out var vList))
+            {
+                vList = new List<float>();
+                groups[texId] = vList;
+                indices[texId] = new List<ushort>();
+            }
+
+            int a = def.faceIndices1[i];
+            int b = def.faceIndices2[i];
+            int c = def.faceIndices3[i];
+
+            float[] u = def.FaceTextureUCoordinates[i];
+            float[] v = def.FaceTextureVCoordinates[i];
+
+            AppendVertex(vList, def, a, u[0], v[0]);
+            indices[texId].Add((ushort)vertIndex++);
+            AppendVertex(vList, def, b, u[1], v[1]);
+            indices[texId].Add((ushort)vertIndex++);
+            AppendVertex(vList, def, c, u[2], v[2]);
+            indices[texId].Add((ushort)vertIndex++);
+        }
+
+        foreach (var kvp in groups)
+        {
+            float[] verts = kvp.Value.ToArray();
+            ushort[] idx = indices[kvp.Key].ToArray();
+
+            int vao = GL.GenVertexArray();
+            int vbo = GL.GenBuffer();
+            int ebo = GL.GenBuffer();
+
+            GL.BindVertexArray(vao);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
+            GL.BufferData(BufferTarget.ArrayBuffer, verts.Length * sizeof(float), verts, BufferUsageHint.StaticDraw);
+            GL.EnableVertexAttribArray(0);
+            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 5 * sizeof(float), 0);
+            GL.EnableVertexAttribArray(1);
+            GL.VertexAttribPointer(1, 2, VertexAttribPointerType.Float, false, 5 * sizeof(float), 3 * sizeof(float));
+
+            GL.BindBuffer(BufferTarget.ElementArrayBuffer, ebo);
+            GL.BufferData(BufferTarget.ElementArrayBuffer, idx.Length * sizeof(ushort), idx, BufferUsageHint.StaticDraw);
+            GL.BindVertexArray(0);
+
+            _batches.Add(new Batch
+            {
+                VAO = vao,
+                VBO = vbo,
+                EBO = ebo,
+                IndexCount = idx.Length,
+                Texture = kvp.Key == -1 ? 0 : textures.GetTexture(kvp.Key)
+            });
+        }
     }
 
-    public void Dispose() {
-        if (_vao != 0) {
-            GL.DeleteBuffer(_vbo);
-            GL.DeleteBuffer(_ebo);
-            GL.DeleteVertexArray(_vao);
-            _vao = _vbo = _ebo = 0;
+    private static void AppendVertex(List<float> list, ModelDefinition def, int vert, float u, float v)
+    {
+        list.Add(def.VertX[vert] / 128f);
+        list.Add(def.VertY[vert] / 128f);
+        list.Add(-def.VertZ[vert] / 128f);
+        list.Add(u);
+        list.Add(v);
+    }
+
+    public void Draw()
+    {
+        foreach (var b in _batches)
+        {
+            if (b.Texture != 0)
+            {
+                GL.ActiveTexture(TextureUnit.Texture0);
+                GL.BindTexture(TextureTarget.Texture2D, b.Texture);
+            }
+            GL.BindVertexArray(b.VAO);
+            GL.DrawElements(PrimitiveType.Triangles, b.IndexCount, DrawElementsType.UnsignedShort, 0);
         }
+        GL.BindVertexArray(0);
+        GL.BindTexture(TextureTarget.Texture2D, 0);
+    }
+
+    public void Dispose()
+    {
+        foreach (var b in _batches)
+        {
+            GL.DeleteBuffer(b.VBO);
+            GL.DeleteBuffer(b.EBO);
+            GL.DeleteVertexArray(b.VAO);
+        }
+        _batches.Clear();
     }
 }

--- a/FlashEditor/Shaders/texture.frag
+++ b/FlashEditor/Shaders/texture.frag
@@ -1,0 +1,7 @@
+#version 330 core
+in vec2 vUv;
+uniform sampler2D uTexture;
+out vec4 FragColor;
+void main() {
+    FragColor = texture(uTexture, vUv);
+}

--- a/FlashEditor/Shaders/texture.vert
+++ b/FlashEditor/Shaders/texture.vert
@@ -1,0 +1,11 @@
+#version 330 core
+layout(location = 0) in vec3 in_position;
+layout(location = 1) in vec2 in_uv;
+uniform mat4 uModel;
+uniform mat4 uView;
+uniform mat4 uProj;
+out vec2 vUv;
+void main() {
+    vUv = in_uv;
+    gl_Position = uProj * uView * uModel * vec4(in_position, 1.0);
+}


### PR DESCRIPTION
## Summary
- implement `GLTextureCache` for creating OpenGL textures from cache
- extend `ModelRenderer` to draw textured batches
- load textures in `Editor` and update shaders
- add new GLSL programs

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_6857f43fbd50832d9242ee627877fb6f