### PR TITLE
Fix texture thumbnails

### DIFF
--- a/FlashEditor/Editor.Designer.cs
+++ b/FlashEditor/Editor.Designer.cs
@@ -1302,7 +1302,9 @@ namespace FlashEditor {
             // 
             TextureImage.AspectName = "thumb";
             TextureImage.Text = "";
-            TextureImage.ImageGetter = row => ((TextureDefinition) row).thumb;
+            // Return the image key instead of the Bitmap so the ListView can
+            // retrieve it from the LargeImageList.
+            TextureImage.ImageGetter = row => ((TextureDefinition) row).id.ToString();
             // 
             // TextureID
             // 


### PR DESCRIPTION
## Summary
- return texture image key so ObjectListView can show thumbnails

## Testing
- `dotnet test FlashEditor.sln -v minimal` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_68580b9eb1c8832d88bc5ff9d43c4130