### PR TITLE
Improve sprite loading reliability and add verbose logging

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -448,8 +448,10 @@ namespace FlashEditor.cache {
         }
 
         public SpriteDefinition GetSprite(int containerId) {
+            Debug($"GetSprite: {containerId}", LOG_DETAIL.ADVANCED);
             //Get the sprite for the given entry
             RSContainer container = GetContainer(RSConstants.SPRITES_INDEX, containerId);
+            Debug($"Container type {container.GetIndexType()} id {container.GetId()} length {container.GetStream().Length}", LOG_DETAIL.INSANE);
             return SpriteDefinition.DecodeFromStream(container.GetStream());
         }
 

--- a/FlashEditor/Definitions/Sprites/SpriteDefinition.cs
+++ b/FlashEditor/Definitions/Sprites/SpriteDefinition.cs
@@ -83,14 +83,17 @@ namespace FlashEditor.cache.sprites {
         /// <param name="stream">The stream.</param>
         /// <returns>The sprite.</returns>
         public void Decode(JagStream stream, int[] xteaKey = null) {
+            Debug("Decoding sprite", LOG_DETAIL.ADVANCED);
             //Find the size of this sprite set
             stream.Seek(stream.Length - 2);
             int size = stream.ReadUnsignedShort();
+            Debug($"Sprite frame count: {size}", LOG_DETAIL.ADVANCED);
 
             //Read the width, height and palette size
             stream.Seek(stream.Length - size * 8 - 7);
             int width = stream.ReadUnsignedShort();
             int height = stream.ReadUnsignedShort();
+            Debug($"Dimensions: {width}x{height}", LOG_DETAIL.ADVANCED);
             int[] palette = new int[stream.ReadByte() + 1];
 
             Debug("Size: " + size + ", width: " + width + ", height: " + height + ", palette elements: " + palette.Length, LOG_DETAIL.INSANE);
@@ -118,7 +121,7 @@ namespace FlashEditor.cache.sprites {
             //Read the pixels themselves
             stream.Seek(0);
             for(int id = 0; id < size; id++) {
-                Debug("\tReading frame " + id, LOG_DETAIL.INSANE);
+                Debug($"\tReading frame {id}", LOG_DETAIL.INSANE);
 
                 //Grab some frequently used values
                 int subWidth = subWidths[id], subHeight = subHeights[id];
@@ -134,7 +137,7 @@ namespace FlashEditor.cache.sprites {
 
                 //Read the flags so we know whether to read horizontally or vertically
                 int flags = stream.ReadByte();
-                //Debug("\t\tFlags [alpha: " + (flags & FLAG_ALPHA) + ", vertical: " + (flags & FLAG_VERTICAL) + "]", LOG_DETAIL.INSANE);
+                Debug($"\t\tFlags [alpha: {(flags & FLAG_ALPHA) != 0}, vertical: {(flags & FLAG_VERTICAL) != 0}]", LOG_DETAIL.INSANE);
 
                 //Read the palette indices
                 if((flags & FLAG_VERTICAL) != 0) {
@@ -188,7 +191,9 @@ namespace FlashEditor.cache.sprites {
                     this.thumb = image.GetSprite();
 
                 this.frames.Add(image);
+                Debug($"\tFinished frame {id}", LOG_DETAIL.INSANE);
             }
+            Debug("Sprite decode complete", LOG_DETAIL.ADVANCED);
         }
 
         /// <summary>

--- a/FlashEditor/Definitions/Sprites/TextureDefinition.cs
+++ b/FlashEditor/Definitions/Sprites/TextureDefinition.cs
@@ -2,6 +2,7 @@ using FlashEditor;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
+using static FlashEditor.Utils.DebugUtil;
 
 namespace FlashEditor.Definitions.Sprites {
     /// <summary>
@@ -33,13 +34,18 @@ namespace FlashEditor.Definitions.Sprites {
         }
 
         public void Decode(JagStream s, int[] xteaKey = null) {
+            Debug($"Decoding texture {id}", LOG_DETAIL.ADVANCED);
             field1777 = s.ReadUnsignedShort();
             field1778 = s.ReadByte() != 0;
 
             int count = s.ReadUnsignedByte();
+            Debug($"Texture has {count} sprite references", LOG_DETAIL.ADVANCED);
             fileIds = new int[count];
             for (int i = 0 ; i < count ; i++)
+            {
                 fileIds[i] = s.ReadUnsignedShort();
+                Debug($"\tSprite file {i}: {fileIds[i]}", LOG_DETAIL.INSANE);
+            }
 
             if (count > 1) {
                 field1780 = new int[count - 1];
@@ -53,10 +59,14 @@ namespace FlashEditor.Definitions.Sprites {
 
             field1786 = new int[count];
             for (int i = 0 ; i < count ; i++)
+            {
                 field1786[i] = s.ReadInt();
+                Debug($"\tColor {i}: 0x{field1786[i]:X8}", LOG_DETAIL.INSANE);
+            }
 
             animationDirection = s.ReadUnsignedByte();
             animationSpeed = s.ReadUnsignedByte();
+            Debug($"Animation dir {animationDirection}, speed {animationSpeed}", LOG_DETAIL.ADVANCED);
         }
 
 

--- a/FlashEditor/Definitions/Sprites/TextureManager.cs
+++ b/FlashEditor/Definitions/Sprites/TextureManager.cs
@@ -2,6 +2,7 @@ using FlashEditor;
 using System.Collections.Generic;
 using System.Drawing;
 using FlashEditor.cache;
+using static FlashEditor.Utils.DebugUtil;
 
 namespace FlashEditor.Definitions.Sprites
 {
@@ -20,22 +21,33 @@ namespace FlashEditor.Definitions.Sprites
 
         public void Load()
         {
+            Debug("Loading texture reference table", LOG_DETAIL.ADVANCED);
             RSReferenceTable table = cache.GetReferenceTable(RSConstants.TEXTURES);
             RSEntry entry = table.GetEntry(0);
             if (entry == null)
+            {
+                Debug("Texture archive 0 not found", LOG_DETAIL.BASIC);
                 return;
+            }
+
+            Debug($"Found {entry.GetValidFileIds().Length} texture entries", LOG_DETAIL.ADVANCED);
 
             var loader = new TextureLoader();
             foreach (int fileId in entry.GetValidFileIds())
             {
+                Debug($"Reading texture {fileId}", LOG_DETAIL.ADVANCED);
                 JagStream data = cache.ReadEntry(RSConstants.TEXTURES, 0, fileId);
-                if(data == null) {
+                if (data == null)
+                {
+                    Debug($"Texture {fileId} returned null data", LOG_DETAIL.BASIC);
                     throw new Exception("Texture entry data is null");
-                    continue;
                 }
+                Debug($"Decoding texture {fileId}", LOG_DETAIL.ADVANCED);
                 var def = loader.Load(fileId, data.ToArray());
+                Debug($"Texture {def.id} references {def.fileIds?.Length ?? 0} sprites", LOG_DETAIL.ADVANCED);
                 Textures[def.id] = def;
             }
+            Debug("Finished loading textures", LOG_DETAIL.BASIC);
         }
 
         internal static Image GetThumbnailForTexture(string key) {

--- a/FlashEditor/Editor.cs
+++ b/FlashEditor/Editor.cs
@@ -371,7 +371,7 @@ namespace FlashEditor {
                     bgw.DoWork += delegate {
                         int done = 0;
                         int total = referenceTable.GetEntryTotal() * 256;
-                        int percentile = total / 100;
+                        int percentile = Math.Max(1, total / 100);
 
                         Debug(@"  _                     _ _               _ _                     ");
                         Debug(@" | |                   | (_)             (_) |                    ");
@@ -441,7 +441,7 @@ namespace FlashEditor {
 
                         int done = 0;
                         int total = referenceTable.GetEntryTotal();
-                        int percentile = total / 100;
+                        int percentile = Math.Max(1, total / 100);
 
                         bgw.ReportProgress(0, "Loading " + total + " Sprites");
                         Debug("Loading " + total + " Sprites");
@@ -505,7 +505,7 @@ namespace FlashEditor {
 
                         int done = 0;
                         int total = referenceTable.GetEntryTotal() * 128;
-                        int percentile = total / 100;
+                        int percentile = Math.Max(1, total / 100);
 
                         bgw.ReportProgress(0, "Loading NPCs");
 
@@ -556,7 +556,7 @@ namespace FlashEditor {
                         int filesPerArchive = referenceTable.GetEntry(referenceTable.GetEntries().Keys.First()).GetValidFileIds().Length;
                         int total = referenceTable.GetEntryTotal() * filesPerArchive;
                         int done = 0;
-                        int percentile = total / 100;
+                        int percentile = Math.Max(1, total / 100);
 
                         bgw.ReportProgress(0, "Loading Objects");
 

--- a/FlashEditor/GLTextureCache.cs
+++ b/FlashEditor/GLTextureCache.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
+using static FlashEditor.Utils.DebugUtil;
 
 namespace FlashEditor
 {
@@ -26,7 +27,9 @@ namespace FlashEditor
         {
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
             _manager = new TextureManager(cache);
+            Debug("Initializing GLTextureCache", LOG_DETAIL.BASIC);
             _manager.Load();
+            Debug("Textures loaded", LOG_DETAIL.BASIC);
         }
 
         /// <summary>
@@ -37,15 +40,21 @@ namespace FlashEditor
         public int GetTexture(int textureId)
         {
             if (_textures.TryGetValue(textureId, out int handle))
+            {
+                Debug($"Texture {textureId} cached -> handle {handle}", LOG_DETAIL.ADVANCED);
                 return handle;
+            }
 
             if (!TextureManager.Textures.TryGetValue(textureId, out TextureDefinition def) || def.fileIds == null || def.fileIds.Length == 0)
                 return 0;
 
+            Debug($"Loading sprite {def.fileIds[0]} for texture {textureId}", LOG_DETAIL.ADVANCED);
             SpriteDefinition sprite = _cache.GetSprite(def.fileIds[0]);
+            Debug($"Creating bitmap for texture {textureId}", LOG_DETAIL.ADVANCED);
             Bitmap bmp = sprite.GetFrame(0).GetSprite();
             handle = CreateGLTexture(bmp);
             _textures[textureId] = handle;
+            Debug($"Texture {textureId} -> GL handle {handle}", LOG_DETAIL.ADVANCED);
             return handle;
         }
 


### PR DESCRIPTION
## Summary
- avoid divide-by-zero when loading sprites/items/NPCs/objects
- add extensive DebugUtil logging for texture manager and sprite loader
- log sprite container info in `RSCache.GetSprite`
- instrument GL texture cache
- enhance texture and sprite definition decoders with debug output

## Testing
- `dotnet test` *(fails: Microsoft.WindowsDesktop.App 9.0.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591ab15cf4832dbee07216684abaf4