### PR TITLE
Improve logging for sprite/texture loading

### DIFF
--- a/FlashEditor/Cache/RSCache.cs
+++ b/FlashEditor/Cache/RSCache.cs
@@ -452,6 +452,7 @@ namespace FlashEditor.cache {
             //Get the sprite for the given entry
             RSContainer container = GetContainer(RSConstants.SPRITES_INDEX, containerId);
             Debug($"Container type {container.GetIndexType()} id {container.GetId()} length {container.GetStream().Length}", LOG_DETAIL.INSANE);
+            Debug($"Decoding sprite container {containerId}", LOG_DETAIL.ADVANCED);
             return SpriteDefinition.DecodeFromStream(container.GetStream());
         }
 

--- a/FlashEditor/Definitions/Sprites/SpriteDefinition.cs
+++ b/FlashEditor/Definitions/Sprites/SpriteDefinition.cs
@@ -117,6 +117,7 @@ namespace FlashEditor.cache.sprites {
                 if(palette[index] == 0)
                     palette[index] = 1;
             }
+            Debug($"Palette loaded with {palette.Length} colours", LOG_DETAIL.ADVANCED);
 
             //Read the pixels themselves
             stream.Seek(0);
@@ -191,7 +192,7 @@ namespace FlashEditor.cache.sprites {
                     this.thumb = image.GetSprite();
 
                 this.frames.Add(image);
-                Debug($"\tFinished frame {id}", LOG_DETAIL.INSANE);
+                Debug($"\tFinished frame {id} ({subWidth}x{subHeight})", LOG_DETAIL.INSANE);
             }
             Debug("Sprite decode complete", LOG_DETAIL.ADVANCED);
         }

--- a/FlashEditor/Definitions/Sprites/TextureDefinition.cs
+++ b/FlashEditor/Definitions/Sprites/TextureDefinition.cs
@@ -46,6 +46,7 @@ namespace FlashEditor.Definitions.Sprites {
                 fileIds[i] = s.ReadUnsignedShort();
                 Debug($"\tSprite file {i}: {fileIds[i]}", LOG_DETAIL.INSANE);
             }
+            Debug($"Parsed {count} sprite references", LOG_DETAIL.ADVANCED);
 
             if (count > 1) {
                 field1780 = new int[count - 1];
@@ -63,10 +64,12 @@ namespace FlashEditor.Definitions.Sprites {
                 field1786[i] = s.ReadInt();
                 Debug($"\tColor {i}: 0x{field1786[i]:X8}", LOG_DETAIL.INSANE);
             }
+            Debug("Color table loaded", LOG_DETAIL.ADVANCED);
 
             animationDirection = s.ReadUnsignedByte();
             animationSpeed = s.ReadUnsignedByte();
             Debug($"Animation dir {animationDirection}, speed {animationSpeed}", LOG_DETAIL.ADVANCED);
+            Debug("Texture decode finished", LOG_DETAIL.ADVANCED);
         }
 
 

--- a/FlashEditor/Definitions/Sprites/TextureManager.cs
+++ b/FlashEditor/Definitions/Sprites/TextureManager.cs
@@ -31,6 +31,7 @@ namespace FlashEditor.Definitions.Sprites
             }
 
             Debug($"Found {entry.GetValidFileIds().Length} texture entries", LOG_DETAIL.ADVANCED);
+            Debug("Beginning texture decode", LOG_DETAIL.ADVANCED);
 
             var loader = new TextureLoader();
             foreach (int fileId in entry.GetValidFileIds())
@@ -44,6 +45,7 @@ namespace FlashEditor.Definitions.Sprites
                 }
                 Debug($"Decoding texture {fileId}", LOG_DETAIL.ADVANCED);
                 var def = loader.Load(fileId, data.ToArray());
+                Debug($"\tLoaded texture {def.id} with {def.fileIds?.Length ?? 0} sprites", LOG_DETAIL.ADVANCED);
                 Debug($"Texture {def.id} references {def.fileIds?.Length ?? 0} sprites", LOG_DETAIL.ADVANCED);
                 Textures[def.id] = def;
             }

--- a/FlashEditor/GLTextureCache.cs
+++ b/FlashEditor/GLTextureCache.cs
@@ -39,6 +39,7 @@ namespace FlashEditor
         /// <returns>OpenGL texture handle or 0 if not found.</returns>
         public int GetTexture(int textureId)
         {
+            Debug($"Request for texture {textureId}", LOG_DETAIL.ADVANCED);
             if (_textures.TryGetValue(textureId, out int handle))
             {
                 Debug($"Texture {textureId} cached -> handle {handle}", LOG_DETAIL.ADVANCED);
@@ -46,12 +47,16 @@ namespace FlashEditor
             }
 
             if (!TextureManager.Textures.TryGetValue(textureId, out TextureDefinition def) || def.fileIds == null || def.fileIds.Length == 0)
+            {
+                Debug($"Texture definition {textureId} not found", LOG_DETAIL.BASIC);
                 return 0;
+            }
 
             Debug($"Loading sprite {def.fileIds[0]} for texture {textureId}", LOG_DETAIL.ADVANCED);
             SpriteDefinition sprite = _cache.GetSprite(def.fileIds[0]);
             Debug($"Creating bitmap for texture {textureId}", LOG_DETAIL.ADVANCED);
             Bitmap bmp = sprite.GetFrame(0).GetSprite();
+            Debug($"Uploading texture {textureId} to GL", LOG_DETAIL.ADVANCED);
             handle = CreateGLTexture(bmp);
             _textures[textureId] = handle;
             Debug($"Texture {textureId} -> GL handle {handle}", LOG_DETAIL.ADVANCED);


### PR DESCRIPTION
## Summary
- add diagnostic output for sprite containers
- log palette and frame details when decoding sprites
- enhance texture loading messages for texture manager and decoder
- trace GL texture creation requests

## Testing
- `dotnet test FlashEditor.Tests/FlashEditor.Tests.csproj --no-build` *(fails: missing .NET runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68591d3c0228832db9ec41f2f46bc2bc