### PR TITLE
Fix triangle index decoding

### DIFF
--- a/FlashEditor/Definitions/ModelDefinition.cs
+++ b/FlashEditor/Definitions/ModelDefinition.cs
@@ -456,19 +456,19 @@ namespace FlashEditor.Definitions {
                 DebugUtil.Debug($" strip[{i}]: op={op}", DebugUtil.LOG_DETAIL.INSANE);
 
                 if (op == 1) {
-                    a = ptr + var4.ReadSignedSmart();
-                    b = a + var4.ReadSignedSmart();
-                    c = b + var4.ReadSignedSmart();
+                    a = ptr + var4.ReadUnsignedSmart();
+                    b = a + var4.ReadUnsignedSmart();
+                    c = b + var4.ReadUnsignedSmart();
                     ptr = c;
                 }
                 else if (op == 2) {
-                    c = ptr + var4.ReadSignedSmart();
+                    c = ptr + var4.ReadUnsignedSmart();
                     ptr = c;
                 }
                 else if (op == 3) {
                     int tmp = a;
                     a = c;
-                    c = ptr + var4.ReadSignedSmart();
+                    c = ptr + var4.ReadUnsignedSmart();
                     ptr = c;
                     b = tmp;
                 }
@@ -477,7 +477,7 @@ namespace FlashEditor.Definitions {
                     int tmp = a;
                     a = b;
                     b = tmp;
-                    c = ptr + var4.ReadSignedSmart();
+                    c = ptr + var4.ReadUnsignedSmart();
                     ptr = c;
                 }
 


### PR DESCRIPTION
## Summary
- decode triangle indices using `ReadUnsignedSmart` in the RS2 decoder
- leave the unused RS3 decoder unchanged

## Testing
- `dotnet test FlashEditor.sln -v minimal` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aa5488b28832dbdfa43f4a8123b33