### PR TITLE
Fix ComputeNormals index safety

### DIFF
--- a/FlashEditor/Definitions/ModelDefinition.cs
+++ b/FlashEditor/Definitions/ModelDefinition.cs
@@ -746,9 +746,15 @@ namespace FlashEditor.Definitions {
                 VertexNormals[i] = new VertexNormal();
 
             for (int i = 0 ; i < TriangleCount ; ++i) {
+                if (i >= faceIndices1.Length || i >= faceIndices2.Length || i >= faceIndices3.Length)
+                    break;
+
                 int vertexA = faceIndices1[i];
                 int vertexB = faceIndices2[i];
                 int vertexC = faceIndices3[i];
+
+                if (vertexA >= VertX.Length || vertexB >= VertX.Length || vertexC >= VertX.Length)
+                    continue;
 
                 int xA = VertX[vertexB] - VertX[vertexA];
                 int yA = VertY[vertexB] - VertY[vertexA];


### PR DESCRIPTION
## Summary
- guard ComputeNormals against invalid triangle/vertex indices

## Testing
- `dotnet build -v minimal FlashEditor.sln`
- `dotnet test -v minimal` *(fails: Microsoft.WindowsDesktop.App runtime missing)*

------
https://chatgpt.com/codex/tasks/task_e_685aac66d0b4832d8e9aa2c7b093c067